### PR TITLE
Codex/rust brain 1.4 agent memory push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented here.
 
 ## Unreleased
 
+### Added
+
+- Added an explicit `rbmem` library target with public APIs for `load`, `save`, `create`, `read`, `update`, `query`, `context`, and `diff`.
+- Added a direct library integration test covering create/update/read/query/context without spawning the CLI.
+- Added a cross-project implementation plan in `docs/IMPLEMENTATION_PLAN.md`.
+- Added section-level AES-256-GCM encryption with `encrypt`, `decrypt`, and read/query `--decrypt` support.
+- Added typed diff rendering and section-level three-way merge with `ours`, `theirs`, `union`, and `manual` strategies.
+- Added `SectionIndex` with keyword, path-prefix, graph adjacency, mtime validation, and disk-cache helpers.
+- Added graph export formats for DOT, Mermaid, Cytoscape JSON, and GEXF.
+- Added Axum HTTP server mode with health, memory, section, query, context, diff, merge, and export routes.
+- Added `update --dry-run`, `delete-section`, `hermes save --json-file`, and `migrate`.
+- Added source content hashes for Markdown sync provenance and `_source_version` tracking for normalized documents.
+- Added parser regression coverage for common LLM-produced RBMEM variants.
+- Added configurable graph inference strategies for Markdown conversion, sync, and `rbmem infer`.
+- Added `--log-format json|text` backed by `tracing` for structured CLI observability.
+- Added RBMEM format version constants and bumped the CLI/library crate to `1.4.0`.
+
+### Changed
+
+- Refactored the core create/read/update/query/context/diff CLI paths to call the library API.
+- Markdown title slugs now use dotted paths consistently.
+- `hermes:memory` writes are enforced as append-only.
+- New writes use RBMEM `1.4.0`; v1.3/v1.3.0 files still parse and normalize with `_source_version`.
+
 ## [0.4.0] - 2026-05-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,10 +71,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -84,6 +171,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -186,12 +279,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -205,6 +351,86 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -303,6 +529,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,10 +547,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -376,6 +629,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +659,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +673,12 @@ dependencies = [
  "fixedbitset",
  "indexmap",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -426,16 +700,55 @@ dependencies = [
 
 [[package]]
 name = "rbmem"
-version = "0.4.0"
+version = "1.4.0"
 dependencies = [
+ "axum",
+ "base64",
  "chrono",
  "clap",
  "nom",
  "notify",
  "petgraph",
+ "ring",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror",
+ "tokio",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -443,6 +756,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -497,10 +816,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "strsim"
@@ -518,6 +904,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "thiserror"
@@ -540,16 +932,171 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+dependencies = [
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "walkdir"
@@ -682,11 +1229,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -700,20 +1256,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -723,9 +1301,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -735,9 +1325,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -747,15 +1349,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rbmem"
-version = "0.4.0"
-authors = ["basbe"]
+version = "1.4.0"
+authors = ["DJLougen"]
 edition = "2021"
 rust-version = "1.82"
 description = "Rust-Brain Memory Format CLI for structured, temporal, graph-aware agent memory."
@@ -14,15 +14,31 @@ keywords = ["agent", "memory", "markdown", "graph", "cli"]
 categories = ["command-line-utilities", "parser-implementations", "data-structures"]
 exclude = ["graphify-out/", "target/"]
 
+[lib]
+name = "rbmem"
+path = "src/lib.rs"
+
+[[bin]]
+name = "rbmem"
+path = "src/main.rs"
+
 [dependencies]
+base64 = "0.22"
+axum = "0.7"
 chrono = { version = "0.4", features = ["serde", "clock"] }
 clap = { version = "4", features = ["derive"] }
 nom = "7"
 notify = "8"
 petgraph = { version = "0.6", optional = true }
+ring = "0.17"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 thiserror = "1"
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "sync"] }
+tower = { version = "0.5", features = ["util"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 
 [features]
 default = ["graph"]

--- a/HERMES.md
+++ b/HERMES.md
@@ -8,6 +8,7 @@ Use `.rbmem` as the durable memory and instruction layer for Hermes agents. Huma
 rbmem hermes init my-project
 rbmem hermes load my-project.rbmem --resolve --minified
 rbmem hermes save my-project.rbmem --json '{"sections":[{"path":"memory","type":"hermes:memory","content":"- User prefers terse context."}]}'
+rbmem hermes save my-project.rbmem --json-file payload.json
 ```
 
 For Markdown folders:
@@ -23,7 +24,8 @@ rbmem sync notes RBMEM-memory --watch --infer-relations
   `rbmem hermes load project.rbmem --resolve --compact`
 - Treat `sections[].path` as the stable memory address.
 - Prefer `hermes:memory` for append-only facts, preferences, and observations.
-- Use `mode: "replace"` only when correcting stale content.
+- `hermes:memory` sections are append-only; use `mode: "auto"` or `mode: "append"`.
+- Use `mode: "replace"` only for non-`hermes:memory` sections when correcting stale content.
 - Never invent timestamps. The tool protects timestamps.
 - Read `graph.edges` for explicit, inferred, and implicit relationships.
 
@@ -111,3 +113,128 @@ rbmem read project.rbmem --resolve --hermes-inject --minified
 ```
 
 This prints a ready-to-paste JSON context block for Hermes prompts.
+
+## Modern RBMEM Capabilities for Hermes
+
+Hermes should prefer the highest-signal RBMEM operation for the job instead of always loading the whole memory file. Use these rules when planning, retrieving context, writing memory, and reviewing changes.
+
+### Context Retrieval
+
+- Use `rbmem query` or `rbmem context` for task-specific retrieval before loading full memory.
+- Use `--resolve` when parent sections contain rules or defaults that child sections inherit.
+- Use `--minified` for model context unless the task requires timestamps, source, graph, or audit metadata.
+- Use `--graph-depth 1` when the task may depend on related sections; increase only when the first result is insufficient.
+- Use `--format json` when another tool, script, or agent step will parse the output.
+
+Recommended commands:
+
+```powershell
+rbmem query project.rbmem "current task or error message" --resolve --minified --graph-depth 1
+rbmem context project.rbmem --task "implement this change safely" --resolve --minified --graph-depth 1 --format json
+```
+
+### Encrypted Sections
+
+Encrypted sections are skipped by normal reads and queries. Hermes must not assume missing secret sections are absent; they may be intentionally encrypted.
+
+- Use encrypted sections for credentials, private user details, API tokens, security notes, and sensitive tool configuration.
+- Do not decrypt unless the current task explicitly needs that content.
+- Prefer `RBMEM_ENCRYPTION_KEY` or `~/.rbmem/key` for non-interactive sessions.
+- Never write decrypted secrets into logs, reports, diffs, traces, or `hermes:memory`.
+
+Recommended commands:
+
+```powershell
+rbmem encrypt project.rbmem --section secrets.api
+rbmem read project.rbmem --resolve --minified --decrypt
+rbmem query project.rbmem "api credential needed for this run" --resolve --minified --decrypt
+rbmem decrypt project.rbmem --section secrets.api
+```
+
+### Safer Change Review
+
+Before and after a material memory update, Hermes should preserve a comparable copy and review the section-level delta.
+
+Recommended workflow:
+
+```powershell
+Copy-Item project.rbmem project.before.rbmem
+rbmem hermes save project.rbmem --json '{"sections":[{"path":"memory","type":"hermes:memory","content":"- New durable fact.","mode":"append"}]}'
+rbmem diff project.before.rbmem project.rbmem --format json
+rbmem review project.rbmem
+rbmem doctor project.rbmem --format json
+```
+
+For branch or multi-agent conflicts, use three-way merge. The `manual` strategy creates `type: conflict` sections instead of silently choosing a side.
+
+```powershell
+rbmem merge base.rbmem local.rbmem remote.rbmem --strategy manual --output merged.rbmem
+rbmem review merged.rbmem
+```
+
+Hermes should treat `type: conflict` sections as blocking review items. Resolve them by replacing the conflict section with the intended final section content.
+
+### Graph-Aware Reasoning
+
+Hermes should inspect graph edges when a task involves dependencies, categories, candidate evolution, tool relationships, or project architecture.
+
+Use graph export for visual review:
+
+```powershell
+rbmem export project.rbmem --format mermaid
+rbmem export project.rbmem --format cytoscape
+rbmem export project.rbmem --format gexf
+```
+
+Use Mermaid output in Markdown reports when humans need to inspect the memory graph. Use Cytoscape or GEXF when an external graph tool will analyze relationships.
+
+### Server Mode
+
+For long-running Hermes sessions, start the RBMEM server once and prefer HTTP calls from runtime tools instead of repeatedly shelling out.
+
+```powershell
+rbmem serve --bind localhost:3000 --dir .\.hermes
+```
+
+Server routes include:
+
+```text
+GET  /health
+POST /memories
+GET  /memories/:name
+PUT  /memories/:name
+DELETE /memories/:name
+GET  /memories/:name/sections/:path
+PUT  /memories/:name/sections/:path
+DELETE /memories/:name/sections/:path
+POST /memories/:name/query
+POST /memories/:name/context
+POST /memories/:name/diff
+POST /memories/:name/merge
+POST /memories/:name/export
+```
+
+Use CLI commands for human-operated workflows and one-off tasks. Use server mode for agent runtimes, repeated queries, local tools, and RBForge integration.
+
+### Harness Decision Rules
+
+- For planning: `query` or `context` first, full `hermes load` only if the selected context is insufficient.
+- For sensitive data: encrypt the section, retrieve with `--decrypt` only for the exact task, and never persist decrypted material elsewhere.
+- For updates: write with `hermes save`, then run `diff`, `review`, and `doctor`.
+- For conflicting memory: run `merge --strategy manual` and treat conflict sections as requiring human or explicit agent resolution.
+- For relationship-heavy tasks: use graph depth during retrieval and `export --format mermaid` for review artifacts.
+- For repeated agent/tool access: start `serve` and use HTTP endpoints.
+
+### Updated Default Hermes Load Pattern
+
+Use the smallest useful context by default:
+
+```powershell
+rbmem context project.rbmem --task "<current task>" --resolve --minified --graph-depth 1 --format json
+```
+
+Fall back to the full Hermes JSON view when the agent needs complete memory state:
+
+```powershell
+rbmem hermes load project.rbmem --resolve --minified
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-`rbmem` is a Rust command-line tool for **Rust-Brain Memory Format** (`.rbmem`) v1.3.
+Rust-Brain is the project. RBMEM is the structured memory format. `rbmem` is the CLI and Rust library for reading, writing, validating, and serving `.rbmem` files.
+
+`rbmem` currently targets **Rust-Brain Memory Format** (`.rbmem`) v1.4.0, while still parsing v1.3 files for migration and compatibility.
 
 RBMEM is a small, readable file format for agent memory, instructions, research notes, project rules, and long-lived context. It keeps the parts humans like about Markdown, but adds the structure agents need: stable section paths, protected timestamps, hierarchy, graph relationships, timelines, validation, and compact context output.
 
@@ -63,16 +65,28 @@ Create a memory file:
 .\target\release\rbmem.exe create memory.rbmem
 ```
 
+```bash
+./target/release/rbmem create memory.rbmem
+```
+
 Add a section:
 
 ```powershell
 .\target\release\rbmem.exe update memory.rbmem --section goals --type list --content "- Ship the project"
 ```
 
+```bash
+./target/release/rbmem update memory.rbmem --section goals --type list --content "- Ship the project"
+```
+
 Read it back:
 
 ```powershell
 .\target\release\rbmem.exe read memory.rbmem
+```
+
+```bash
+./target/release/rbmem read memory.rbmem
 ```
 
 Feed the smallest useful resolved view to an agent:
@@ -88,15 +102,20 @@ Ask RBMEM for task-specific context:
 .\target\release\rbmem.exe context memory.rbmem --task "review this PR" --resolve --minified
 ```
 
+```bash
+./target/release/rbmem query memory.rbmem "github code review" --resolve --minified --graph-depth 1
+./target/release/rbmem context memory.rbmem --task "review this PR" --resolve --minified
+```
+
 ## RBMEM At A Glance
 
 An RBMEM file is plain text:
 
 ```rbmem
-rbmem# RBMEM v1.3 - Rust-Brain Memory Format
+rbmem# RBMEM v1.4.0 - Rust-Brain Memory Format
 
 meta:
-  version: 1.3
+  version: 1.4.0
   purpose: "personal-agent-memory"
   generated_at: "2026-04-27T13:10:00Z"
   last_updated: "2026-04-27T13:10:00Z"
@@ -124,7 +143,7 @@ The CLI protects timestamps during import/update flows, so model-generated times
 Convert one Markdown file:
 
 ```powershell
-.\target\release\rbmem.exe convert-from-md examples\sample.md examples\from_md.rbmem --infer-relations
+.\target\release\rbmem.exe convert-from-md examples\sample.md examples\from_md.rbmem --infer-relations --inference-strategy balanced
 ```
 
 Markdown headings become dotted paths:
@@ -146,7 +165,7 @@ agents.reader.capabilities
 Sync a whole Markdown folder:
 
 ```powershell
-.\target\release\rbmem.exe sync C:\notes C:\agent-memory --infer-relations --min-confidence 0.7
+.\target\release\rbmem.exe sync C:\notes C:\agent-memory --infer-relations --min-confidence 0.7 --inference-strategy explicit
 ```
 
 Watch for changes:
@@ -154,6 +173,14 @@ Watch for changes:
 ```powershell
 .\target\release\rbmem.exe sync C:\notes C:\agent-memory --watch --infer-relations
 ```
+
+Infer graph relations on an existing file:
+
+```powershell
+.\target\release\rbmem.exe infer memory.rbmem --inference-strategy aggressive --min-confidence 0.7
+```
+
+Inference strategies are `off`, `explicit`, `balanced`, and `aggressive`. `balanced` is the default and preserves the original heuristic; `explicit` only accepts prose with relation verbs such as "uses" or "depends on"; `aggressive` lowers the effective threshold for broader recall.
 
 ## Hermes Harness Workflow
 
@@ -261,25 +288,143 @@ See [HERMES.md](HERMES.md) for agent instructions and the save payload shape. Se
 | `read <file.rbmem> --resolve` | Apply hierarchy merge rules before rendering. |
 | `read <file.rbmem> --resolve --compact` | Hide most metadata for shorter context. |
 | `read <file.rbmem> --resolve --minified` | Smallest agent-oriented text view. |
+| `read <file.rbmem> --decrypt` | Include encrypted sections after resolving the encryption key. |
 | `update <file.rbmem> --section <path>` | Safely add or update one section. |
+| `update <file.rbmem> --section <path> --dry-run` | Preview an update without writing it. |
+| `delete-section <file.rbmem> --section <path>` | Remove one section by path. |
+| `prune <file.rbmem>` | Remove expired sections. |
+| `encrypt <file.rbmem> --section <path>` | Encrypt one section with AES-256-GCM. |
+| `decrypt <file.rbmem> --section <path>` | Persistently decrypt one encrypted section. |
 | `convert-from-md <in.md> <out.rbmem>` | Convert Markdown headings into dotted RBMEM paths. |
 | `sync <md-folder> <out-folder>` | Convert a Markdown folder into RBMEM files. |
 | `infer <file.rbmem>` | Infer graph relations from prose. |
-| `query <file.rbmem> <text>` | Return matching task-specific context; use `--format json` for tool callers. |
-| `context <file.rbmem> --task <text>` | Alias for task-oriented context assembly; use `--format json` for tool callers. |
+| `query <file.rbmem> <text>` | Return matching task-specific context; use `--format json` or `--decrypt` when needed. |
+| `context <file.rbmem> --task <text>` | Alias for task-oriented context assembly; use `--format json` or `--decrypt` when needed. |
 | `pack <file.rbmem> <name>` | Render a named context pack from `.rbmempacks`; use `--format json` for tool callers. |
-| `diff <before.rbmem> <after.rbmem>` | Report section-level memory changes. |
+| `diff <before.rbmem> <after.rbmem> --format text|json|yaml` | Report typed section-level memory changes. |
+| `merge <base.rbmem> <local.rbmem> <remote.rbmem> --strategy manual` | Run a three-way section merge. |
+| `migrate <file.rbmem> --dry-run` | Explicitly normalize older RBMEM documents and preserve `_source_version`. |
 | `review <file.rbmem>` | Validate and flag agent-written or inferred memory for human review. |
 | `doctor [file.rbmem]` | Report CLI version, RBMEM format version, parse status, validation status, section count, and graph edges; supports `--format json`. |
+| `--log-format json` | Emit structured `tracing` logs; pair with `RUST_LOG=info`. |
 | `graph <file.rbmem> --format json` | Export graph nodes and edges. |
 | `graph <file.rbmem> --format dot` | Export a DOT graph. |
+| `export <file.rbmem> --format dot|mermaid|cytoscape|gexf` | Export graph visualizations for Graphviz, Markdown, Cytoscape, or Gephi. |
+| `serve --bind localhost:3000 --dir <memory_dir>` | Run the Axum REST API server. |
 | `tree <file.rbmem>` | Show section hierarchy. |
 | `timeline <file.rbmem>` | Show temporal entries. |
 | `validate <file.rbmem>` | Validate parser compatibility. |
 | `hermes load <file.rbmem>` | Output Hermes-friendly JSON. |
 | `hermes save <file.rbmem> --json <payload>` | Apply Hermes-style memory updates. |
+| `hermes save <file.rbmem> --json-file payload.json` | Apply Hermes updates from a file. |
 | `hermes doctor <file.rbmem>` | Check RBMEM memory health and verify Hermes JSON/context loading; supports `--format json`. |
 | `hermes watch <file.rbmem>` | Watch a file and print Hermes JSON on changes. |
+
+## Encryption
+
+Encrypted sections use AES-256-GCM and are stored as `type: encrypted` with `nonce`, `ciphertext`, and `encrypted_at`. Normal reads and queries skip encrypted sections. Add `--decrypt` when the caller should resolve the key and include decrypted content.
+
+Key lookup order is:
+
+1. `RBMEM_ENCRYPTION_KEY`
+2. `~/.rbmem/key`
+3. interactive prompt
+
+The key must be 32 raw bytes or base64-encoded 32 bytes.
+
+```powershell
+$env:RBMEM_ENCRYPTION_KEY = "<base64-encoded-32-byte-key>"
+rbmem encrypt memory.rbmem --section secrets.api
+rbmem read memory.rbmem
+rbmem read memory.rbmem --decrypt
+rbmem query memory.rbmem "api token" --decrypt
+rbmem decrypt memory.rbmem --section secrets.api
+```
+
+## Diff, Merge, Export, And Server
+
+Typed diffs can render as text, JSON, or YAML:
+
+```powershell
+rbmem diff base.rbmem changed.rbmem --format json
+```
+
+Three-way merge compares `base`, `local`, and `remote` at section granularity. `manual` creates `type: conflict` sections when both sides changed the same section.
+
+```powershell
+rbmem merge base.rbmem local.rbmem remote.rbmem --strategy manual --output merged.rbmem
+```
+
+Graph exports support DOT, Mermaid, Cytoscape JSON, and GEXF:
+
+```powershell
+rbmem export memory.rbmem --format mermaid
+rbmem export memory.rbmem --format gexf
+```
+
+The HTTP server exposes health, memory CRUD, section CRUD, query, context, diff, merge, and export routes:
+
+```powershell
+rbmem serve --bind localhost:3000 --dir .\memories
+```
+
+## Rust Library API
+
+Rust-Brain now builds both a `rbmem` binary and a `rbmem` library crate. The CLI remains the supported human-facing interface, while Rust callers can use the same create, read, update, query, context, load, save, and diff behavior without spawning a process.
+
+```rust
+use chrono::Utc;
+use rbmem::{
+    create, query, update, ContextOptions, CreateOptions, OutputFormat, SectionType,
+    TimestampPolicy, UpdateOptions,
+};
+
+# fn demo() -> Result<(), rbmem::RbmemError> {
+let file = "memory.rbmem";
+let now = Utc::now();
+
+create(
+    file,
+    CreateOptions {
+        created_by: "agent".to_string(),
+        purpose: "personal-agent-memory".to_string(),
+        default_expiry_days: None,
+        human: false,
+        now,
+    },
+)?;
+
+update(
+    file,
+    UpdateOptions {
+        section: "agents.reader".to_string(),
+        section_type: SectionType::Text,
+        content: "Reads memory carefully.".to_string(),
+        human: false,
+        dry_run: false,
+        now,
+    },
+)?;
+
+let context = query(
+    file,
+    "reader",
+    ContextOptions {
+        resolve: true,
+        compact: false,
+        minified: true,
+        graph_depth: 0,
+        decrypt: false,
+        key: None,
+        format: OutputFormat::Text,
+        policy: TimestampPolicy::Preserve,
+    },
+)?;
+# Ok(())
+# }
+```
+
+Library functions return `Result<T, RbmemError>`. New writes use RBMEM v1.4.0, while v1.3 files still parse and normalize with `_source_version`.
 
 ## RBMEM vs Markdown: Real Measurements
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,6 +40,8 @@ RBMEM graph output combines:
 - Manual relations written in a section's `graph.relations`.
 - Inferred relations added by `convert-from-md --infer-relations` or `rbmem infer`.
 
+Inference is configurable with `--inference-strategy off|explicit|balanced|aggressive`. `balanced` preserves the default heuristic, `explicit` accepts only direct relation phrases, and `aggressive` lowers the effective confidence threshold for recall-heavy agent indexing. Markdown sync can set the same behavior in `.rbmemsync` with `inference_strategy: explicit`.
+
 Graph JSON marks each edge source so agents can distinguish trusted manual edges from inferred ones.
 
 ## Timestamp Protection

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,109 @@
+# Rust-Brain + RBForge Implementation Plan
+
+This plan keeps Rust-Brain as the format authority and moves RBForge toward an agent tool runtime that can use Rust-Brain over a stable API. Work is split into compileable milestones so each stage can ship independently.
+
+## Phase 1: Rust-Brain 1.4 Foundation
+
+### Milestone 1: Library Crate Restructure
+
+Goal: make the existing CLI behavior available as a Rust library without changing RBMEM v1.3 file compatibility or CLI commands.
+
+- Add a public command API in `src/lib.rs` for `load`, `save`, `create`, `read`, `update`, `query`, `context`, and the document-level helpers needed by current commands.
+- Keep `src/main.rs` responsible for CLI parsing, stdout/stderr, and process exit only.
+- Return `Result<T, RbmemError>` from library functions and avoid `process::exit` in the library path.
+- Add `Debug`, `Clone`, and `PartialEq` to public API option/result structs.
+- Preserve v1.3 parser and serializer behavior exactly.
+- Add integration tests that call the library directly and compare CLI-compatible output.
+
+### Milestone 2: Section-Level Encryption
+
+Goal: protect individual sections while leaving the surrounding document readable and mergeable.
+
+- Add `SectionType::Encrypted` while preserving v1.3 parsing for existing files.
+- Implement AES-256-GCM encryption/decryption in `src/crypto.rs` using `ring`.
+- Resolve keys in priority order: `RBMEM_ENCRYPTION_KEY`, `~/.rbmem/key`, interactive prompt.
+- Store encrypted payload metadata as `nonce`, `ciphertext`, and `encrypted_at`.
+- Add `rbmem encrypt --section`, `rbmem decrypt --section`, and `--decrypt` for read/query paths.
+- Skip encrypted sections in normal read/query results unless decryption is explicitly requested.
+
+### Milestone 3: Diff/Merge Engine
+
+Goal: support collaboration and branch reconciliation at section granularity.
+
+- Add typed `SectionDiff` and `RbmemDiff` models.
+- Implement two-way diff for add/remove/type/content/metadata changes.
+- Implement three-way merge over base/local/remote with `ours`, `theirs`, `union`, and `manual` strategies.
+- Emit RBMEM conflict sections with `type: conflict`, `conflict_at`, `local_version`, and `remote_version`.
+- Add text, JSON, and YAML-compatible output renderers.
+
+### Milestone 4: Query Performance Index
+
+Goal: make large `.rbmem` files fast enough for repeated agent queries.
+
+- Build an in-memory inverted keyword index.
+- Add a path trie for prefix queries such as `agents.*`.
+- Add graph adjacency lists for `related()` breadth-first search up to depth `N`.
+- Invalidate cached indexes when file modified time changes.
+- Add optional `.rbmem.index` disk cache after correctness tests are stable.
+
+### Milestone 5: Graph Visualization Export
+
+Goal: export RBMEM graph structure into common visualization tools.
+
+- Add exporters for DOT, Mermaid, Cytoscape JSON, and GEXF.
+- Include implicit hierarchy edges and explicit graph relations such as `depends_on` and `categorized_as`.
+- Add `rbmem export memory.rbmem --format dot|mermaid|cytoscape|gexf`.
+
+### Milestone 6: HTTP Server Mode
+
+Goal: give RBForge and other tools a stable programmatic interface without shelling out.
+
+- Add Axum server under `src/server/mod.rs`.
+- Store loaded memories in an `AppState` guarded by `tokio::sync::RwLock`.
+- Add endpoints for health, memory CRUD, section CRUD, query, context, diff, merge, and export.
+- Add request/response JSON types with explicit error mapping.
+
+## Phase 2: RBForge Runtime Expansion
+
+### Milestone 7: RBForge HTTP Client + Version Gate
+
+- Add `rbforge_core/rbmem_client.py` for Rust-Brain server calls.
+- Keep subprocess fallback in CLI only.
+- Add version constants and require `rbmem >= 1.4.0` while accepting v1.3 files.
+
+### Milestone 8: Resource-Limited Multi-Language Runners
+
+- Introduce `ToolRunner` ABC.
+- Move existing Python execution into `PythonRunner`.
+- Add optional `WasmRunner` using `wasmtime`.
+- Add `DenoRunner` with `deno run --allow-none`.
+- Enforce per-category CPU, memory, file-size, and timeout limits.
+
+### Milestone 9: Dependencies and Variants
+
+- Store declared dependencies in tool metadata.
+- Resolve dependencies by topological sort and detect cycles with `CircularDependencyError`.
+- Pass dependency results as context to dependent tools.
+- Add variants and A/B testing with duration, success, and correctness comparison.
+
+### Milestone 10: Auto-Improvement and Deprecation
+
+- Track recent failures and success rates.
+- Detect common Python error families and propose focused improvements.
+- Store tool versions under `tools.custom.{name}.versions[]`.
+- Audit tools for low success rate or inactivity and archive with full history.
+
+### Milestone 11: Observability, MCP, and Marketplace
+
+- Add structured JSON logging in Rust-Brain via `tracing`.
+- Add JSON Lines logging in RBForge via `structlog`.
+- Store telemetry under `telemetry.events`.
+- Add MCP resources and tools for registry, forge, run, query, and update operations.
+- Add signed tool export/import using Ed25519 signatures.
+
+## End-to-End Validation
+
+- Keep v1.3 fixtures loading throughout all milestones.
+- Add Rust integration tests for encryption, diff/merge, export, and server endpoints.
+- Add Python tests for each RBForge runtime feature.
+- Finish with cross-project tests that forge tools into `.rbmem`, query them through the Rust-Brain server, run them through RBForge, and verify telemetry.

--- a/docs/RELEASE_NOTES_1.4.0.md
+++ b/docs/RELEASE_NOTES_1.4.0.md
@@ -1,0 +1,26 @@
+# Rust-Brain / RBMEM 1.4.0 Release Notes
+
+## Highlights
+
+- Rust-Brain now exposes a public `rbmem` library API in addition to the CLI.
+- New RBMEM writes use format version `1.4.0`.
+- Existing RBMEM v1.3 files still parse and normalize with `_source_version`.
+- Section-level AES-256-GCM encryption is available through `encrypt`, `decrypt`, and `--decrypt` read/query flows.
+- Section-level diff, three-way merge, graph export, indexing, and Axum server mode are available.
+- CLI observability now supports `--log-format json` with `RUST_LOG`.
+
+## Compatibility
+
+RBMEM v1.3 files remain loadable. When older documents are parsed or migrated,
+Rust-Brain preserves the original version in `_source_version` and writes the
+current document as RBMEM `1.4.0`.
+
+## Validation
+
+Validated with:
+
+- `cargo fmt --check`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test --all-features`
+- Real CLI smoke flow for create, update, read, encrypt, decrypt, diff, merge,
+  export, Markdown conversion, doctor JSON, and JSON logging.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,726 @@
+use crate::document::graph_view_to_json;
+use crate::parser::parse_document;
+use crate::{crypto, diff as diff_engine, DiffFormat, EncryptionKey};
+use crate::{
+    CompactMode, RbmemDocument, RbmemError, Section, SectionType, SourceInfo, TimestampPolicy,
+};
+use chrono::{DateTime, Utc};
+use clap::ValueEnum;
+use serde_json::{json, Value};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    Text,
+    Json,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateOptions {
+    pub created_by: String,
+    pub purpose: String,
+    pub default_expiry_days: Option<i64>,
+    pub human: bool,
+    pub now: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReadOptions {
+    pub resolve: bool,
+    pub compact: bool,
+    pub minified: bool,
+    pub hide_empty_temporal: bool,
+    pub decrypt: bool,
+    pub key: Option<EncryptionKey>,
+    pub policy: TimestampPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UpdateOptions {
+    pub section: String,
+    pub section_type: SectionType,
+    pub content: String,
+    pub human: bool,
+    pub dry_run: bool,
+    pub now: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContextOptions {
+    pub resolve: bool,
+    pub compact: bool,
+    pub minified: bool,
+    pub graph_depth: usize,
+    pub decrypt: bool,
+    pub key: Option<EncryptionKey>,
+    pub format: OutputFormat,
+    pub policy: TimestampPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContextOutputRequest {
+    pub operation: String,
+    pub file: String,
+    pub selector_name: String,
+    pub selector_value: String,
+    pub resolve: bool,
+    pub compact: bool,
+    pub minified: bool,
+    pub graph_depth: usize,
+    pub format: OutputFormat,
+}
+
+pub fn load(path: impl AsRef<Path>, policy: TimestampPolicy) -> Result<RbmemDocument, RbmemError> {
+    let input = fs::read_to_string(path)?;
+    Ok(parse_document(&input, policy)?.document)
+}
+
+pub fn save(
+    path: impl AsRef<Path>,
+    document: &RbmemDocument,
+    human: bool,
+) -> Result<(), RbmemError> {
+    let text = if human {
+        document.to_human_rbmem_string()
+    } else {
+        document.to_rbmem_string()
+    };
+    fs::write(path, text)?;
+    Ok(())
+}
+
+pub fn create(path: impl AsRef<Path>, options: CreateOptions) -> Result<RbmemDocument, RbmemError> {
+    let mut document = RbmemDocument::new(options.now, options.created_by);
+    document.meta.purpose = options.purpose;
+    document.meta.default_expiry_days = options.default_expiry_days;
+    save(path, &document, options.human)?;
+    Ok(document)
+}
+
+pub fn delete_section(
+    path: impl AsRef<Path>,
+    section_path: &str,
+    dry_run: bool,
+    now: DateTime<Utc>,
+) -> Result<RbmemDocument, RbmemError> {
+    let path = path.as_ref();
+    let mut document = load(path, TimestampPolicy::Preserve)?;
+    let before = document.sections.len();
+    document
+        .sections
+        .retain(|section| section.path != section_path);
+    if document.sections.len() == before {
+        return Err(RbmemError::Parse(format!(
+            "section '{section_path}' not found"
+        )));
+    }
+    document.meta.last_updated = now;
+    if !dry_run {
+        save(path, &document, false)?;
+    }
+    Ok(document)
+}
+
+pub fn read(path: impl AsRef<Path>, options: ReadOptions) -> Result<String, RbmemError> {
+    let document = load(path, options.policy)?;
+    let document = prepare_encrypted_sections(document, options.decrypt, options.key.as_ref())?;
+    Ok(render_read_document(&document, &options))
+}
+
+pub fn update(path: impl AsRef<Path>, options: UpdateOptions) -> Result<RbmemDocument, RbmemError> {
+    let path = path.as_ref();
+    let mut document = if path.exists() {
+        load(path, TimestampPolicy::Preserve)?
+    } else {
+        RbmemDocument::new(options.now, "me")
+    };
+
+    document.upsert_section(
+        &options.section,
+        options.section_type,
+        options.content,
+        options.now,
+    );
+    set_section_source(
+        &mut document,
+        &options.section,
+        SourceInfo {
+            kind: "cli".to_string(),
+            path: None,
+            actor: Some("me".to_string()),
+            hash: None,
+        },
+    );
+    document.enforce_protected_timestamps(options.now);
+    if !options.dry_run {
+        save(path, &document, options.human)?;
+    }
+    Ok(document)
+}
+
+pub fn query(
+    path: impl AsRef<Path>,
+    text: &str,
+    options: ContextOptions,
+) -> Result<String, RbmemError> {
+    let path = path.as_ref();
+    let document = load(path, options.policy)?;
+    let document = prepare_encrypted_sections(document, options.decrypt, options.key.as_ref())?;
+    let context = query_document(&document, text, options.resolve, options.graph_depth);
+    render_context_output(
+        ContextOutputRequest {
+            operation: "query".to_string(),
+            file: path.display().to_string(),
+            selector_name: "text".to_string(),
+            selector_value: text.to_string(),
+            resolve: options.resolve,
+            compact: options.compact,
+            minified: options.minified,
+            graph_depth: options.graph_depth,
+            format: options.format,
+        },
+        &document,
+        &context,
+    )
+}
+
+pub fn context(
+    path: impl AsRef<Path>,
+    task: &str,
+    options: ContextOptions,
+) -> Result<String, RbmemError> {
+    let path = path.as_ref();
+    let document = load(path, options.policy)?;
+    let document = prepare_encrypted_sections(document, options.decrypt, options.key.as_ref())?;
+    let context = query_document(&document, task, options.resolve, options.graph_depth);
+    render_context_output(
+        ContextOutputRequest {
+            operation: "context".to_string(),
+            file: path.display().to_string(),
+            selector_name: "task".to_string(),
+            selector_value: task.to_string(),
+            resolve: options.resolve,
+            compact: options.compact,
+            minified: options.minified,
+            graph_depth: options.graph_depth,
+            format: options.format,
+        },
+        &document,
+        &context,
+    )
+}
+
+pub fn diff(before: impl AsRef<Path>, after: impl AsRef<Path>) -> Result<String, RbmemError> {
+    diff_file_with_format(before, after, DiffFormat::Text)
+}
+
+pub fn diff_file_with_format(
+    before: impl AsRef<Path>,
+    after: impl AsRef<Path>,
+    format: DiffFormat,
+) -> Result<String, RbmemError> {
+    let before = load(before, TimestampPolicy::Preserve)?;
+    let after = load(after, TimestampPolicy::Preserve)?;
+    diff_engine::diff_with_format(&before, &after, format)
+}
+
+pub fn encrypt_section(
+    path: impl AsRef<Path>,
+    section_path: &str,
+    key: &EncryptionKey,
+    now: DateTime<Utc>,
+) -> Result<RbmemDocument, RbmemError> {
+    let path = path.as_ref();
+    let mut document = load(path, TimestampPolicy::Preserve)?;
+    let section = document
+        .sections
+        .iter_mut()
+        .find(|section| section.path == section_path)
+        .ok_or_else(|| RbmemError::Parse(format!("section '{section_path}' not found")))?;
+
+    if section.section_type != SectionType::Encrypted {
+        let payload = crypto::encrypt_content(&section.content, key, now)?;
+        section.section_type = SectionType::Encrypted;
+        section.encrypted = Some(payload);
+        section.content.clear();
+        section.temporal.updated_at = now;
+        document.meta.last_updated = now;
+        save(path, &document, false)?;
+    }
+
+    Ok(document)
+}
+
+pub fn decrypt_section(
+    path: impl AsRef<Path>,
+    section_path: &str,
+    key: &EncryptionKey,
+    now: DateTime<Utc>,
+) -> Result<RbmemDocument, RbmemError> {
+    let path = path.as_ref();
+    let mut document = load(path, TimestampPolicy::Preserve)?;
+    let section = document
+        .sections
+        .iter_mut()
+        .find(|section| section.path == section_path)
+        .ok_or_else(|| RbmemError::Parse(format!("section '{section_path}' not found")))?;
+
+    let payload = section
+        .encrypted
+        .as_ref()
+        .ok_or_else(|| RbmemError::Parse(format!("section '{section_path}' is not encrypted")))?;
+    section.content = crypto::decrypt_content(payload, key)?;
+    section.section_type = SectionType::Text;
+    section.encrypted = None;
+    section.temporal.updated_at = now;
+    document.meta.last_updated = now;
+    save(path, &document, false)?;
+
+    Ok(document)
+}
+
+pub fn query_document(
+    document: &RbmemDocument,
+    query: &str,
+    include_parents: bool,
+    graph_depth: usize,
+) -> RbmemDocument {
+    let query_terms = query_terms(query);
+    let phrase = normalize_for_query(query);
+    let mut selected = query_matches(document, &query_terms, &phrase);
+
+    if include_parents {
+        include_parent_sections(document, &mut selected);
+    }
+
+    include_graph_neighbors(document, &mut selected, graph_depth);
+    subset_document(document, selected)
+}
+
+pub fn render_context_document(
+    document: &RbmemDocument,
+    resolve: bool,
+    compact: bool,
+    minified: bool,
+) -> String {
+    if minified || (!compact && document.meta.compact_mode == CompactMode::Minified) {
+        document.to_minified_string(resolve)
+    } else if compact || document.meta.compact_mode == CompactMode::Compact {
+        document.to_compact_string(resolve, Utc::now())
+    } else {
+        document.to_rbmem_string_hiding_empty_temporal()
+    }
+}
+
+pub fn render_context_output(
+    request: ContextOutputRequest,
+    source: &RbmemDocument,
+    context: &RbmemDocument,
+) -> Result<String, RbmemError> {
+    match request.format {
+        OutputFormat::Text => Ok(render_context_document(
+            context,
+            request.resolve,
+            request.compact,
+            request.minified,
+        )),
+        OutputFormat::Json => Ok(serde_json::to_string_pretty(&context_json(
+            request, source, context,
+        ))?),
+    }
+}
+
+pub fn context_json(
+    request: ContextOutputRequest,
+    source: &RbmemDocument,
+    context: &RbmemDocument,
+) -> Value {
+    json!({
+        "schema": "rbmem.context.v1",
+        "operation": request.operation,
+        "file": request.file,
+        "selector": {
+            "kind": request.selector_name,
+            "value": request.selector_value,
+        },
+        "options": {
+            "resolve": request.resolve,
+            "compact": request.compact,
+            "minified": request.minified,
+            "graph_depth": request.graph_depth,
+        },
+        "source": {
+            "meta": document_meta_json(source),
+            "section_count": source.sections.len(),
+        },
+        "context": render_context_document(
+            context,
+            request.resolve,
+            request.compact,
+            request.minified,
+        ),
+        "context_meta": document_meta_json(context),
+        "sections": sections_json(context, request.resolve),
+        "graph": graph_view_to_json(&context.graph_view()),
+    })
+}
+
+pub fn diff_documents(before: &RbmemDocument, after: &RbmemDocument) -> String {
+    diff_engine::diff_with_format(before, after, DiffFormat::Text)
+        .unwrap_or_else(|error| format!("error rendering diff: {error}\n"))
+}
+
+pub fn read_content_argument(
+    content: Option<String>,
+    content_file: Option<impl AsRef<Path>>,
+) -> Result<String, RbmemError> {
+    match (content, content_file) {
+        (Some(content), None) => Ok(content),
+        (None, Some(path)) => Ok(fs::read_to_string(path)?),
+        (Some(_), Some(_)) => Err(RbmemError::Parse(
+            "use either --content or --content-file, not both".to_string(),
+        )),
+        (None, None) => Err(RbmemError::Parse(
+            "missing --content or --content-file".to_string(),
+        )),
+    }
+}
+
+fn render_read_document(document: &RbmemDocument, options: &ReadOptions) -> String {
+    if options.minified
+        || (options.resolve
+            && !options.compact
+            && document.meta.compact_mode == CompactMode::Minified)
+    {
+        document.to_minified_string(options.resolve)
+    } else if options.compact
+        || (options.resolve && document.meta.compact_mode == CompactMode::Compact)
+    {
+        document.to_compact_string(options.resolve, Utc::now())
+    } else if options.resolve {
+        render_resolved_sections(document)
+    } else if options.hide_empty_temporal {
+        document.to_rbmem_string_hiding_empty_temporal()
+    } else {
+        document.to_rbmem_string()
+    }
+}
+
+fn prepare_encrypted_sections(
+    mut document: RbmemDocument,
+    decrypt: bool,
+    key: Option<&EncryptionKey>,
+) -> Result<RbmemDocument, RbmemError> {
+    if decrypt {
+        let resolved_key;
+        let key = match key {
+            Some(key) => key,
+            None => {
+                resolved_key = EncryptionKey::resolve()?;
+                &resolved_key
+            }
+        };
+        decrypt_document_sections(&mut document, key)?;
+    } else {
+        document
+            .sections
+            .retain(|section| section.section_type != SectionType::Encrypted);
+    }
+
+    Ok(document)
+}
+
+fn decrypt_document_sections(
+    document: &mut RbmemDocument,
+    key: &EncryptionKey,
+) -> Result<(), RbmemError> {
+    for section in &mut document.sections {
+        if section.section_type != SectionType::Encrypted {
+            continue;
+        }
+        let payload = section.encrypted.as_ref().ok_or_else(|| {
+            RbmemError::Crypto(format!(
+                "encrypted section '{}' is missing encrypted payload fields",
+                section.path
+            ))
+        })?;
+        section.content = crypto::decrypt_content(payload, key)?;
+        section.section_type = SectionType::Text;
+    }
+    Ok(())
+}
+
+fn render_resolved_sections(document: &RbmemDocument) -> String {
+    let mut output = String::new();
+    for section in document.resolved_sections() {
+        output.push_str(&format!(
+            "[{}] type={}\n",
+            section.path, section.section_type
+        ));
+        output.push_str(&section.content);
+        output.push_str("\n\n");
+    }
+    output
+}
+
+fn query_matches(document: &RbmemDocument, terms: &[String], phrase: &str) -> BTreeSet<String> {
+    let mut scored = document
+        .sections
+        .iter()
+        .filter_map(|section| {
+            let score = query_score(section, terms, phrase);
+            (score > 0).then_some((section.path.clone(), score))
+        })
+        .collect::<Vec<_>>();
+
+    scored.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+    scored.into_iter().map(|(path, _)| path).collect()
+}
+
+fn query_score(section: &Section, terms: &[String], phrase: &str) -> usize {
+    let path = normalize_for_query(&section.path);
+    let content = normalize_for_query(&section.content);
+    let mut score = 0;
+
+    if !phrase.is_empty() {
+        if path.contains(phrase) {
+            score += 20;
+        }
+        if content.contains(phrase) {
+            score += 12;
+        }
+    }
+
+    for term in terms {
+        if path.contains(term) {
+            score += 5;
+        }
+        if content.contains(term) {
+            score += 1;
+        }
+    }
+
+    score
+}
+
+fn include_parent_sections(document: &RbmemDocument, selected: &mut BTreeSet<String>) {
+    let known_paths = document
+        .sections
+        .iter()
+        .map(|section| section.path.as_str())
+        .collect::<BTreeSet<_>>();
+    let matched = selected.iter().cloned().collect::<Vec<_>>();
+
+    for path in matched {
+        let parts = path.split('.').collect::<Vec<_>>();
+        for depth in 1..parts.len() {
+            let parent = parts[..depth].join(".");
+            if known_paths.contains(parent.as_str()) {
+                selected.insert(parent);
+            }
+        }
+    }
+}
+
+fn include_graph_neighbors(
+    document: &RbmemDocument,
+    selected: &mut BTreeSet<String>,
+    graph_depth: usize,
+) {
+    if graph_depth == 0 || selected.is_empty() {
+        return;
+    }
+
+    let known_paths = document
+        .sections
+        .iter()
+        .map(|section| section.path.clone())
+        .collect::<BTreeSet<_>>();
+    let graph = document.graph_view();
+    let mut frontier = selected.clone();
+
+    for _ in 0..graph_depth {
+        let mut next = BTreeSet::new();
+        for edge in &graph.edges {
+            if frontier.contains(&edge.from) && known_paths.contains(&edge.to) {
+                next.insert(edge.to.clone());
+            }
+            if frontier.contains(&edge.to) && known_paths.contains(&edge.from) {
+                next.insert(edge.from.clone());
+            }
+        }
+
+        let before = selected.len();
+        selected.extend(next.iter().cloned());
+        if selected.len() == before {
+            break;
+        }
+        frontier = next;
+    }
+}
+
+fn subset_document(document: &RbmemDocument, selected: BTreeSet<String>) -> RbmemDocument {
+    let mut subset = document.clone();
+    subset
+        .sections
+        .retain(|section| selected.contains(&section.path));
+    subset
+}
+
+fn query_terms(text: &str) -> Vec<String> {
+    normalize_for_query(text)
+        .split_whitespace()
+        .filter(|term| term.len() > 1)
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn normalize_for_query(text: &str) -> String {
+    let mut output = String::new();
+    let mut last_was_space = true;
+
+    for ch in text.chars() {
+        if ch.is_ascii_alphanumeric() {
+            output.push(ch.to_ascii_lowercase());
+            last_was_space = false;
+        } else if !last_was_space {
+            output.push(' ');
+            last_was_space = true;
+        }
+    }
+
+    output.trim().to_string()
+}
+
+fn set_section_source(document: &mut RbmemDocument, path: &str, source: SourceInfo) {
+    if let Some(section) = document
+        .sections
+        .iter_mut()
+        .find(|section| section.path == path)
+    {
+        section.source = Some(source);
+    }
+}
+
+fn document_meta_json(document: &RbmemDocument) -> Value {
+    json!({
+        "version": document.meta.version,
+        "source_version": document.meta.source_version,
+        "purpose": document.meta.purpose,
+        "generated_at": document.meta.generated_at,
+        "last_updated": document.meta.last_updated,
+        "valid_until": document.meta.valid_until,
+        "created_by": document.meta.created_by,
+        "default_expiry_days": document.meta.default_expiry_days,
+        "compact_mode": document.meta.compact_mode.to_string(),
+    })
+}
+
+fn sections_json(document: &RbmemDocument, resolve: bool) -> Vec<Value> {
+    if resolve {
+        document
+            .resolved_sections()
+            .into_iter()
+            .map(|section| {
+                json!({
+                    "path": section.path,
+                    "type": section.section_type.to_string(),
+                    "temporal": {
+                        "created_at": section.temporal.created_at,
+                        "updated_at": section.temporal.updated_at,
+                        "expires_at": section.temporal.expires_at,
+                    },
+                    "source": section.source,
+                    "graph": section.graph,
+                    "content": section.content,
+                })
+            })
+            .collect()
+    } else {
+        document
+            .sections
+            .iter()
+            .map(|section| {
+                json!({
+                    "path": section.path,
+                    "type": section.section_type.to_string(),
+                    "temporal": {
+                        "created_at": section.temporal.created_at,
+                        "updated_at": section.temporal.updated_at,
+                        "expires_at": section.temporal.expires_at,
+                    },
+                    "source": section.source,
+                    "graph": section.graph,
+                    "content": section.content,
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn fixed_time() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn query_context_includes_matches_parents_and_graph_neighbors() {
+        let now = fixed_time();
+        let mut document = RbmemDocument::new(now, "me");
+        document.upsert_section("rules", SectionType::List, "- Base".to_string(), now);
+        document.upsert_section(
+            "rules.review",
+            SectionType::Text,
+            "Review pull requests.".to_string(),
+            now,
+        );
+        document.upsert_section(
+            "memory.testing",
+            SectionType::Text,
+            "Run Rust tests.".to_string(),
+            now,
+        );
+        document.sections[1].graph = Some(crate::document::GraphInfo {
+            node_type: None,
+            relations: vec![crate::GraphRelation {
+                to: "memory.testing".to_string(),
+                relation_type: "depends_on".to_string(),
+                valid_from: Some(now),
+                valid_until: None,
+                inferred: false,
+                confidence: None,
+            }],
+        });
+
+        let context = query_document(&document, "pull requests", true, 1);
+        let paths = context
+            .sections
+            .iter()
+            .map(|section| section.path.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(paths, vec!["memory.testing", "rules", "rules.review"]);
+    }
+
+    #[test]
+    fn diff_reports_added_and_changed_sections() {
+        let now = fixed_time();
+        let mut before = RbmemDocument::new(now, "me");
+        before.upsert_section("rules", SectionType::Text, "old".to_string(), now);
+
+        let mut after = before.clone();
+        after.upsert_section("rules", SectionType::Text, "new".to_string(), now);
+        after.upsert_section("memory", SectionType::Text, "added".to_string(), now);
+
+        let diff = diff_documents(&before, &after);
+
+        assert!(diff.contains("added: memory"));
+        assert!(diff.contains("changed content: rules"));
+    }
+}

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,122 @@
+use crate::{EncryptedPayload, RbmemError};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use chrono::{DateTime, Utc};
+use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, AES_256_GCM};
+use ring::rand::{SecureRandom, SystemRandom};
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncryptionKey {
+    bytes: [u8; 32],
+}
+
+impl EncryptionKey {
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self { bytes }
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.bytes
+    }
+
+    pub fn from_env_value(value: &str) -> Result<Self, RbmemError> {
+        let trimmed = value.trim();
+        if let Ok(decoded) = STANDARD.decode(trimmed) {
+            return Self::from_slice(&decoded);
+        }
+        Self::from_slice(trimmed.as_bytes())
+    }
+
+    pub fn resolve() -> Result<Self, RbmemError> {
+        if let Ok(value) = std::env::var("RBMEM_ENCRYPTION_KEY") {
+            if !value.trim().is_empty() {
+                return Self::from_env_value(&value);
+            }
+        }
+
+        if let Some(path) = default_key_path() {
+            if path.exists() {
+                return Self::from_env_value(&fs::read_to_string(path)?);
+            }
+        }
+
+        print!("RBMEM encryption key: ");
+        io::stdout().flush()?;
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        Self::from_env_value(&input)
+    }
+
+    fn from_slice(bytes: &[u8]) -> Result<Self, RbmemError> {
+        let bytes: [u8; 32] = bytes.try_into().map_err(|_| {
+            RbmemError::Crypto("encryption key must be 32 bytes or base64-encoded 32 bytes".into())
+        })?;
+        Ok(Self { bytes })
+    }
+}
+
+pub fn encrypt_content(
+    plaintext: &str,
+    key: &EncryptionKey,
+    encrypted_at: DateTime<Utc>,
+) -> Result<EncryptedPayload, RbmemError> {
+    let rng = SystemRandom::new();
+    let mut nonce_bytes = [0u8; 12];
+    rng.fill(&mut nonce_bytes)
+        .map_err(|_| RbmemError::Crypto("failed to generate encryption nonce".into()))?;
+
+    let sealing_key = less_safe_key(key)?;
+    let nonce = Nonce::assume_unique_for_key(nonce_bytes);
+    let mut in_out = plaintext.as_bytes().to_vec();
+    sealing_key
+        .seal_in_place_append_tag(nonce, Aad::empty(), &mut in_out)
+        .map_err(|_| RbmemError::Crypto("failed to encrypt section".into()))?;
+
+    Ok(EncryptedPayload {
+        nonce: STANDARD.encode(nonce_bytes),
+        ciphertext: STANDARD.encode(in_out),
+        encrypted_at,
+    })
+}
+
+pub fn decrypt_content(
+    payload: &EncryptedPayload,
+    key: &EncryptionKey,
+) -> Result<String, RbmemError> {
+    let nonce_bytes = STANDARD
+        .decode(&payload.nonce)
+        .map_err(|error| RbmemError::Crypto(format!("invalid encrypted section nonce: {error}")))?;
+    let nonce_bytes: [u8; 12] = nonce_bytes
+        .try_into()
+        .map_err(|_| RbmemError::Crypto("encrypted section nonce must be 12 bytes".into()))?;
+    let mut in_out = STANDARD.decode(&payload.ciphertext).map_err(|error| {
+        RbmemError::Crypto(format!("invalid encrypted section ciphertext: {error}"))
+    })?;
+
+    let opening_key = less_safe_key(key)?;
+    let plaintext = opening_key
+        .open_in_place(
+            Nonce::assume_unique_for_key(nonce_bytes),
+            Aad::empty(),
+            &mut in_out,
+        )
+        .map_err(|_| RbmemError::Crypto("failed to decrypt section".into()))?;
+
+    String::from_utf8(plaintext.to_vec())
+        .map_err(|error| RbmemError::Crypto(format!("decrypted section is not UTF-8: {error}")))
+}
+
+fn less_safe_key(key: &EncryptionKey) -> Result<LessSafeKey, RbmemError> {
+    let unbound = UnboundKey::new(&AES_256_GCM, key.as_bytes())
+        .map_err(|_| RbmemError::Crypto("failed to initialize AES-256-GCM key".into()))?;
+    Ok(LessSafeKey::new(unbound))
+}
+
+fn default_key_path() -> Option<PathBuf> {
+    std::env::var_os("USERPROFILE")
+        .or_else(|| std::env::var_os("HOME"))
+        .map(PathBuf::from)
+        .map(|home| home.join(".rbmem").join("key"))
+}

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,289 @@
+use crate::{RbmemDocument, RbmemError, Section, SectionType};
+use chrono::{DateTime, Utc};
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum DiffFormat {
+    Text,
+    Json,
+    Yaml,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum MergeStrategy {
+    Ours,
+    Theirs,
+    Union,
+    Manual,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SectionDiffKind {
+    Added,
+    Removed,
+    Changed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SectionDiff {
+    pub path: String,
+    pub kind: SectionDiffKind,
+    pub fields: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RbmemDiff {
+    pub schema: String,
+    pub changes: Vec<SectionDiff>,
+}
+
+pub fn diff_documents_typed(before: &RbmemDocument, after: &RbmemDocument) -> RbmemDiff {
+    let before_by_path = section_map(before);
+    let after_by_path = section_map(after);
+    let paths = before_by_path
+        .keys()
+        .chain(after_by_path.keys())
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let mut changes = Vec::new();
+
+    for path in paths {
+        match (before_by_path.get(path), after_by_path.get(path)) {
+            (None, Some(_)) => changes.push(SectionDiff {
+                path: path.to_string(),
+                kind: SectionDiffKind::Added,
+                fields: Vec::new(),
+            }),
+            (Some(_), None) => changes.push(SectionDiff {
+                path: path.to_string(),
+                kind: SectionDiffKind::Removed,
+                fields: Vec::new(),
+            }),
+            (Some(before), Some(after)) => {
+                let fields = changed_fields(before, after);
+                if !fields.is_empty() {
+                    changes.push(SectionDiff {
+                        path: path.to_string(),
+                        kind: SectionDiffKind::Changed,
+                        fields,
+                    });
+                }
+            }
+            (None, None) => {}
+        }
+    }
+
+    RbmemDiff {
+        schema: "rbmem.diff.v1".to_string(),
+        changes,
+    }
+}
+
+pub fn diff_with_format(
+    before: &RbmemDocument,
+    after: &RbmemDocument,
+    format: DiffFormat,
+) -> Result<String, RbmemError> {
+    let diff = diff_documents_typed(before, after);
+    match format {
+        DiffFormat::Text => Ok(render_diff_text(&diff)),
+        DiffFormat::Json => Ok(serde_json::to_string_pretty(&diff)?),
+        DiffFormat::Yaml => serde_yaml::to_string(&diff)
+            .map_err(|error| RbmemError::Parse(format!("failed to render YAML diff: {error}"))),
+    }
+}
+
+pub fn merge_documents(
+    base: &RbmemDocument,
+    local: &RbmemDocument,
+    remote: &RbmemDocument,
+    strategy: MergeStrategy,
+    now: DateTime<Utc>,
+) -> RbmemDocument {
+    let base_by_path = section_map(base);
+    let local_by_path = section_map(local);
+    let remote_by_path = section_map(remote);
+    let paths = base_by_path
+        .keys()
+        .chain(local_by_path.keys())
+        .chain(remote_by_path.keys())
+        .copied()
+        .collect::<BTreeSet<_>>();
+
+    let mut merged = base.clone();
+    merged.sections.clear();
+    merged.meta.last_updated = now;
+
+    for path in paths {
+        let base_section = base_by_path.get(path).copied();
+        let local_section = local_by_path.get(path).copied();
+        let remote_section = remote_by_path.get(path).copied();
+
+        if let Some(section) = merge_section(
+            path,
+            base_section,
+            local_section,
+            remote_section,
+            strategy,
+            now,
+        ) {
+            merged.sections.push(section);
+        }
+    }
+
+    merged
+        .sections
+        .sort_by(|left, right| left.path.cmp(&right.path));
+    merged
+}
+
+pub fn render_diff_text(diff: &RbmemDiff) -> String {
+    let mut output = String::new();
+    for change in &diff.changes {
+        match change.kind {
+            SectionDiffKind::Added => output.push_str(&format!("added: {}\n", change.path)),
+            SectionDiffKind::Removed => output.push_str(&format!("removed: {}\n", change.path)),
+            SectionDiffKind::Changed => {
+                for field in &change.fields {
+                    output.push_str(&format!("changed {field}: {}\n", change.path));
+                }
+            }
+        }
+    }
+
+    if output.is_empty() {
+        output.push_str("no RBMEM differences\n");
+    }
+
+    output
+}
+
+fn merge_section(
+    path: &str,
+    base: Option<&Section>,
+    local: Option<&Section>,
+    remote: Option<&Section>,
+    strategy: MergeStrategy,
+    now: DateTime<Utc>,
+) -> Option<Section> {
+    if sections_equal(local, remote) {
+        return local.cloned();
+    }
+    if sections_equal(local, base) {
+        return remote.cloned();
+    }
+    if sections_equal(remote, base) {
+        return local.cloned();
+    }
+
+    match strategy {
+        MergeStrategy::Ours => local.cloned(),
+        MergeStrategy::Theirs => remote.cloned(),
+        MergeStrategy::Union => union_sections(local, remote),
+        MergeStrategy::Manual => Some(conflict_section(path, local, remote, now)),
+    }
+}
+
+fn union_sections(local: Option<&Section>, remote: Option<&Section>) -> Option<Section> {
+    match (local, remote) {
+        (Some(local), Some(remote)) => {
+            let mut section = local.clone();
+            if local.content != remote.content && !remote.content.trim().is_empty() {
+                if !section.content.trim().is_empty() {
+                    section.content.push('\n');
+                }
+                section.content.push_str(remote.content.trim());
+            }
+            Some(section)
+        }
+        (Some(local), None) => Some(local.clone()),
+        (None, Some(remote)) => Some(remote.clone()),
+        (None, None) => None,
+    }
+}
+
+fn conflict_section(
+    path: &str,
+    local: Option<&Section>,
+    remote: Option<&Section>,
+    now: DateTime<Utc>,
+) -> Section {
+    let mut section = Section::new(path, SectionType::Conflict, now);
+    section.content = format!(
+        "conflict_at: \"{}\"\nlocal_version: |\n{}\nremote_version: |\n{}",
+        now.to_rfc3339(),
+        indent_block(local.map(|section| section.content.as_str()).unwrap_or("")),
+        indent_block(remote.map(|section| section.content.as_str()).unwrap_or(""))
+    );
+    section
+}
+
+fn indent_block(value: &str) -> String {
+    value
+        .lines()
+        .map(|line| format!("  {line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn changed_fields(before: &Section, after: &Section) -> Vec<String> {
+    let mut fields = Vec::new();
+    if before.section_type != after.section_type {
+        fields.push("type".to_string());
+    }
+    if before.content != after.content {
+        fields.push("content".to_string());
+    }
+    if before.temporal != after.temporal {
+        fields.push("temporal".to_string());
+    }
+    if before.source != after.source {
+        fields.push("source".to_string());
+    }
+    if before.graph != after.graph {
+        fields.push("graph".to_string());
+    }
+    if before.encrypted != after.encrypted {
+        fields.push("encrypted".to_string());
+    }
+    fields
+}
+
+fn sections_equal(left: Option<&Section>, right: Option<&Section>) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) => section_semantic_key(left) == section_semantic_key(right),
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+fn section_semantic_key(section: &Section) -> SectionSemanticKey<'_> {
+    SectionSemanticKey {
+        section_type: section.section_type,
+        source: section.source.as_ref(),
+        graph: section.graph.as_ref(),
+        encrypted: section.encrypted.as_ref(),
+        content: section.content.as_str(),
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct SectionSemanticKey<'a> {
+    section_type: SectionType,
+    source: Option<&'a crate::SourceInfo>,
+    graph: Option<&'a crate::document::GraphInfo>,
+    encrypted: Option<&'a crate::EncryptedPayload>,
+    content: &'a str,
+}
+
+fn section_map(document: &RbmemDocument) -> BTreeMap<&str, &Section> {
+    document
+        .sections
+        .iter()
+        .map(|section| (section.path.as_str(), section))
+        .collect()
+}

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,4 +1,6 @@
+use crate::version::{is_supported_format_version, RBMEM_FORMAT_LABEL, RBMEM_FORMAT_VERSION};
 use chrono::{DateTime, Duration, Utc};
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -17,6 +19,9 @@ pub enum RbmemError {
     #[error("parse error: {0}")]
     Parse(String),
 
+    #[error("cryptography error: {0}")]
+    Crypto(String),
+
     #[error("invalid section type: {0}")]
     InvalidSectionType(String),
 
@@ -29,7 +34,7 @@ pub enum RbmemError {
 /// `Preserve` is useful when simply reading a trusted file. `Protect` is used
 /// when importing or updating LLM-produced content: incoming timestamps are
 /// ignored and replaced by the tool's clock.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TimestampPolicy {
     Preserve,
     Protect { now: DateTime<Utc> },
@@ -38,6 +43,8 @@ pub enum TimestampPolicy {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Meta {
     pub version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_version: Option<String>,
     pub purpose: String,
     pub generated_at: DateTime<Utc>,
     pub last_updated: DateTime<Utc>,
@@ -50,7 +57,8 @@ pub struct Meta {
 impl Meta {
     pub fn new(now: DateTime<Utc>, created_by: impl Into<String>) -> Self {
         Self {
-            version: "1.3".to_string(),
+            version: RBMEM_FORMAT_VERSION.to_string(),
+            source_version: None,
             purpose: "personal-agent-memory".to_string(),
             generated_at: now,
             last_updated: now,
@@ -62,12 +70,19 @@ impl Meta {
     }
 
     pub fn enforce_v13(&mut self, warnings: &mut Vec<String>) {
-        if self.version != "1.3" {
-            warnings.push(format!(
-                "document version '{}' was normalized to locked RBMEM v1.3",
-                self.version
-            ));
-            self.version = "1.3".to_string();
+        if self.version != RBMEM_FORMAT_VERSION {
+            let original = self.version.clone();
+            self.source_version = Some(self.version.clone());
+            if is_supported_format_version(&original) {
+                warnings.push(format!(
+                    "legacy document version '{original}' was normalized to {RBMEM_FORMAT_LABEL}"
+                ));
+            } else {
+                warnings.push(format!(
+                    "document version '{original}' was normalized to {RBMEM_FORMAT_LABEL}"
+                ));
+            }
+            self.version = RBMEM_FORMAT_VERSION.to_string();
         }
     }
 }
@@ -104,6 +119,61 @@ impl FromStr for CompactMode {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum InferenceStrategy {
+    Off,
+    Explicit,
+    #[default]
+    Balanced,
+    Aggressive,
+}
+
+impl InferenceStrategy {
+    fn effective_min_confidence(self, min_confidence: f64) -> f64 {
+        let min_confidence = min_confidence.clamp(0.0, 1.0);
+        match self {
+            Self::Aggressive => (min_confidence - 0.10).clamp(0.0, 1.0),
+            _ => min_confidence,
+        }
+    }
+
+    fn allows_candidate_kind(self, kind: InferredRelationKind) -> bool {
+        match self {
+            Self::Off => false,
+            Self::Explicit => kind == InferredRelationKind::Explicit,
+            Self::Balanced | Self::Aggressive => true,
+        }
+    }
+}
+
+impl Display for InferenceStrategy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Off => f.write_str("off"),
+            Self::Explicit => f.write_str("explicit"),
+            Self::Balanced => f.write_str("balanced"),
+            Self::Aggressive => f.write_str("aggressive"),
+        }
+    }
+}
+
+impl FromStr for InferenceStrategy {
+    type Err = RbmemError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "off" | "none" | "disabled" => Ok(Self::Off),
+            "explicit" | "strict" | "conservative" => Ok(Self::Explicit),
+            "balanced" | "default" => Ok(Self::Balanced),
+            "aggressive" => Ok(Self::Aggressive),
+            other => Err(RbmemError::Parse(format!(
+                "invalid inference strategy: {other}"
+            ))),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum SectionType {
@@ -114,6 +184,8 @@ pub enum SectionType {
     Timeline,
     Template,
     HermesMemory,
+    Encrypted,
+    Conflict,
 }
 
 impl SectionType {
@@ -125,6 +197,8 @@ impl SectionType {
             SectionType::Timeline => "timeline",
             SectionType::Template => "template",
             SectionType::HermesMemory => "hermes:memory",
+            SectionType::Encrypted => "encrypted",
+            SectionType::Conflict => "conflict",
         }
     }
 }
@@ -146,9 +220,18 @@ impl FromStr for SectionType {
             "timeline" => Ok(Self::Timeline),
             "template" => Ok(Self::Template),
             "hermes:memory" | "hermes_memory" | "hermes-memory" => Ok(Self::HermesMemory),
+            "encrypted" => Ok(Self::Encrypted),
+            "conflict" => Ok(Self::Conflict),
             other => Err(RbmemError::InvalidSectionType(other.to_string())),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EncryptedPayload {
+    pub nonce: String,
+    pub ciphertext: String,
+    pub encrypted_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -202,6 +285,8 @@ pub struct SourceInfo {
     pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub actor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -211,6 +296,7 @@ pub struct Section {
     pub temporal: Temporal,
     pub source: Option<SourceInfo>,
     pub graph: Option<GraphInfo>,
+    pub encrypted: Option<EncryptedPayload>,
     pub content: String,
 }
 
@@ -222,6 +308,7 @@ impl Section {
             temporal: Temporal::new(now, None),
             source: None,
             graph: None,
+            encrypted: None,
             content: String::new(),
         }
     }
@@ -246,6 +333,7 @@ pub struct ResolvedSection {
     pub temporal: Temporal,
     pub source: Option<SourceInfo>,
     pub graph: Option<GraphInfo>,
+    pub encrypted: Option<EncryptedPayload>,
     pub content: String,
 }
 
@@ -287,9 +375,9 @@ impl RbmemDocument {
     pub fn validate(&self) -> Vec<String> {
         let mut warnings = Vec::new();
 
-        if self.meta.version != "1.3" {
+        if !is_supported_format_version(&self.meta.version) {
             warnings.push(format!(
-                "expected RBMEM version 1.3, found {}",
+                "expected RBMEM version {RBMEM_FORMAT_VERSION}, found {}",
                 self.meta.version
             ));
         }
@@ -327,7 +415,20 @@ impl RbmemDocument {
     }
 
     pub fn infer_relations(&mut self, now: DateTime<Utc>, min_confidence: f64) -> usize {
-        let min_confidence = min_confidence.clamp(0.0, 1.0);
+        self.infer_relations_with_strategy(now, min_confidence, InferenceStrategy::Balanced)
+    }
+
+    pub fn infer_relations_with_strategy(
+        &mut self,
+        now: DateTime<Utc>,
+        min_confidence: f64,
+        strategy: InferenceStrategy,
+    ) -> usize {
+        if strategy == InferenceStrategy::Off {
+            return 0;
+        }
+
+        let min_confidence = strategy.effective_min_confidence(min_confidence);
         let known_paths: Vec<String> = self
             .sections
             .iter()
@@ -336,7 +437,8 @@ impl RbmemDocument {
         let mut added = 0;
 
         for section in &mut self.sections {
-            let inferred = infer_section_relations(section, &known_paths, now, min_confidence);
+            let inferred =
+                infer_section_relations(section, &known_paths, now, min_confidence, strategy);
             if inferred.is_empty() {
                 continue;
             }
@@ -383,6 +485,7 @@ impl RbmemDocument {
                 section_type
             };
             section.section_type = section_type;
+            section.encrypted = None;
             section.content = merge_update_content(merge_type, &section.content, &content);
             section.temporal.updated_at = now;
             return;
@@ -551,7 +654,13 @@ impl RbmemDocument {
     pub fn to_compact_string(&self, resolve: bool, now: DateTime<Utc>) -> String {
         let mut output = String::new();
         output.push_str("meta:\n");
-        output.push_str("  version: 1.3\n");
+        output.push_str(&format!("  version: {}\n", self.meta.version));
+        if let Some(source_version) = &self.meta.source_version {
+            output.push_str(&format!(
+                "  _source_version: \"{}\"\n",
+                escape_string(source_version)
+            ));
+        }
         output.push_str(&format!(
             "  purpose: \"{}\"\n\n",
             escape_string(&self.meta.purpose)
@@ -568,7 +677,11 @@ impl RbmemDocument {
                         format_optional_time(section.temporal.expires_at)
                     ));
                 }
-                write_content_block(&mut output, &section.content, RbmemWriteStyle::Canonical);
+                if section.section_type == SectionType::Encrypted {
+                    write_encrypted_fields(&mut output, section.encrypted.as_ref());
+                } else {
+                    write_content_block(&mut output, &section.content, RbmemWriteStyle::Canonical);
+                }
                 output.push_str("[END SECTION]\n\n");
             }
         } else {
@@ -582,7 +695,11 @@ impl RbmemDocument {
                         format_optional_time(section.temporal.expires_at)
                     ));
                 }
-                write_content_block(&mut output, &section.content, RbmemWriteStyle::Canonical);
+                if section.section_type == SectionType::Encrypted {
+                    write_encrypted_fields(&mut output, section.encrypted.as_ref());
+                } else {
+                    write_content_block(&mut output, &section.content, RbmemWriteStyle::Canonical);
+                }
                 output.push_str("[END SECTION]\n\n");
             }
         }
@@ -632,15 +749,17 @@ impl RbmemDocument {
         let mut output = String::new();
         match options.style {
             RbmemWriteStyle::Canonical => {
-                output.push_str("rbmem# RBMEM v1.3 - Rust-Brain Memory Format\n\n");
+                output.push_str(&format!(
+                    "rbmem# {RBMEM_FORMAT_LABEL} - Rust-Brain Memory Format\n\n"
+                ));
             }
             RbmemWriteStyle::Human => {
-                output.push_str("# RBMEM v1.3 human-editable file\n");
+                output.push_str(&format!("# {RBMEM_FORMAT_LABEL} human-editable file\n"));
                 output.push_str("# The parser accepts these short section delimiters.\n\n");
             }
         }
         output.push_str("meta:\n");
-        output.push_str("  version: 1.3\n");
+        output.push_str(&format!("  version: {}\n", self.meta.version));
         output.push_str(&format!(
             "  purpose: \"{}\"\n",
             escape_string(&self.meta.purpose)
@@ -707,6 +826,9 @@ impl RbmemDocument {
                 if let Some(actor) = &source.actor {
                     output.push_str(&format!("  actor: \"{}\"\n", escape_string(actor)));
                 }
+                if let Some(hash) = &source.hash {
+                    output.push_str(&format!("  hash: \"{}\"\n", escape_string(hash)));
+                }
             }
 
             if let Some(graph) = &section.graph {
@@ -744,7 +866,11 @@ impl RbmemDocument {
                 }
             }
 
-            write_content_block(&mut output, &section.content, options.style);
+            if section.section_type == SectionType::Encrypted {
+                write_encrypted_fields(&mut output, section.encrypted.as_ref());
+            } else {
+                write_content_block(&mut output, &section.content, options.style);
+            }
             match options.style {
                 RbmemWriteStyle::Canonical => output.push_str("[END SECTION]\n\n"),
                 RbmemWriteStyle::Human => output.push_str("=== END SECTION\n\n"),
@@ -810,6 +936,7 @@ fn merge_section_chain(chain: &[&Section]) -> ResolvedSection {
         temporal: resolved.temporal,
         source: resolved.source,
         graph: resolved.graph,
+        encrypted: resolved.encrypted,
         content: resolved.content,
     }
 }
@@ -866,6 +993,7 @@ fn infer_section_relations(
     known_paths: &[String],
     now: DateTime<Utc>,
     min_confidence: f64,
+    strategy: InferenceStrategy,
 ) -> Vec<GraphRelation> {
     let text = normalize_for_matching(&section.content);
     let mut relations = Vec::new();
@@ -875,7 +1003,7 @@ fn infer_section_relations(
             continue;
         }
 
-        if let Some(candidate) = infer_relation_candidate(&text, target) {
+        if let Some(candidate) = infer_relation_candidate(&text, target, strategy) {
             if candidate.confidence < min_confidence {
                 continue;
             }
@@ -898,9 +1026,21 @@ fn infer_section_relations(
 struct InferredRelationCandidate {
     relation_type: String,
     confidence: f64,
+    kind: InferredRelationKind,
 }
 
-fn infer_relation_candidate(text: &str, target_path: &str) -> Option<InferredRelationCandidate> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InferredRelationKind {
+    Explicit,
+    VerbWindow,
+    Mention,
+}
+
+fn infer_relation_candidate(
+    text: &str,
+    target_path: &str,
+    strategy: InferenceStrategy,
+) -> Option<InferredRelationCandidate> {
     let aliases = target_aliases(target_path);
     let mut best: Option<InferredRelationCandidate> = None;
 
@@ -916,7 +1056,9 @@ fn infer_relation_candidate(text: &str, target_path: &str) -> Option<InferredRel
                     InferredRelationCandidate {
                         relation_type: pattern.relation_type.to_string(),
                         confidence: pattern.confidence,
+                        kind: InferredRelationKind::Explicit,
                     },
+                    strategy,
                 );
             }
         }
@@ -927,7 +1069,9 @@ fn infer_relation_candidate(text: &str, target_path: &str) -> Option<InferredRel
                 InferredRelationCandidate {
                     relation_type: "references".to_string(),
                     confidence: 0.72,
+                    kind: InferredRelationKind::VerbWindow,
                 },
+                strategy,
             );
         }
 
@@ -940,7 +1084,9 @@ fn infer_relation_candidate(text: &str, target_path: &str) -> Option<InferredRel
                 } else {
                     0.60
                 },
+                kind: InferredRelationKind::Mention,
             },
+            strategy,
         );
     }
 
@@ -1002,7 +1148,15 @@ const RELATION_PATTERNS: &[RelationPattern] = &[
     },
 ];
 
-fn push_best(best: &mut Option<InferredRelationCandidate>, candidate: InferredRelationCandidate) {
+fn push_best(
+    best: &mut Option<InferredRelationCandidate>,
+    candidate: InferredRelationCandidate,
+    strategy: InferenceStrategy,
+) {
+    if !strategy.allows_candidate_kind(candidate.kind) {
+        return;
+    }
+
     if best
         .as_ref()
         .is_none_or(|current| candidate.confidence > current.confidence)
@@ -1274,6 +1428,20 @@ fn write_content_block(output: &mut String, content: &str, style: RbmemWriteStyl
     }
 }
 
+fn write_encrypted_fields(output: &mut String, encrypted: Option<&EncryptedPayload>) {
+    if let Some(payload) = encrypted {
+        output.push_str(&format!("nonce: \"{}\"\n", escape_string(&payload.nonce)));
+        output.push_str(&format!(
+            "ciphertext: \"{}\"\n",
+            escape_string(&payload.ciphertext)
+        ));
+        output.push_str(&format!(
+            "encrypted_at: \"{}\"\n",
+            payload.encrypted_at.to_rfc3339()
+        ));
+    }
+}
+
 pub fn graph_view_to_json(view: &GraphView) -> Value {
     let nodes = view.nodes.iter().map(|id| json!({ "id": id })).collect();
     let edges = view
@@ -1506,6 +1674,78 @@ mod tests {
             .unwrap();
         assert!(doc.sections[alpha_index].graph.is_none());
         assert_eq!(doc.infer_relations(now, 0.6), 1);
+    }
+
+    #[test]
+    fn relation_inference_strategy_off_disables_edges() {
+        let now = fixed_time();
+        let mut doc = RbmemDocument::new(now, "me");
+        doc.upsert_section(
+            "agents.reader",
+            SectionType::Text,
+            "The reader uses writer.".to_string(),
+            now,
+        );
+        doc.upsert_section(
+            "agents.writer",
+            SectionType::Text,
+            "Writer.".to_string(),
+            now,
+        );
+
+        assert_eq!(
+            doc.infer_relations_with_strategy(now, 0.6, InferenceStrategy::Off),
+            0
+        );
+        assert!(doc.sections[0].graph.is_none());
+    }
+
+    #[test]
+    fn relation_inference_explicit_strategy_ignores_mentions() {
+        let now = fixed_time();
+        let mut doc = RbmemDocument::new(now, "me");
+        doc.upsert_section(
+            "notes.alpha",
+            SectionType::Text,
+            "Alpha mentions beta without an action verb.".to_string(),
+            now,
+        );
+        doc.upsert_section("notes.beta", SectionType::Text, "Beta.".to_string(), now);
+
+        assert_eq!(
+            doc.infer_relations_with_strategy(now, 0.6, InferenceStrategy::Explicit),
+            0
+        );
+    }
+
+    #[test]
+    fn relation_inference_aggressive_strategy_lowers_threshold() {
+        let now = fixed_time();
+        let mut balanced = RbmemDocument::new(now, "me");
+        balanced.upsert_section(
+            "notes.alpha",
+            SectionType::Text,
+            "Alpha mentions beta without an action verb.".to_string(),
+            now,
+        );
+        balanced.upsert_section("notes.beta", SectionType::Text, "Beta.".to_string(), now);
+        assert_eq!(
+            balanced.infer_relations_with_strategy(now, 0.69, InferenceStrategy::Balanced),
+            0
+        );
+
+        let mut aggressive = RbmemDocument::new(now, "me");
+        aggressive.upsert_section(
+            "notes.alpha",
+            SectionType::Text,
+            "Alpha mentions beta without an action verb.".to_string(),
+            now,
+        );
+        aggressive.upsert_section("notes.beta", SectionType::Text, "Beta.".to_string(), now);
+        assert_eq!(
+            aggressive.infer_relations_with_strategy(now, 0.69, InferenceStrategy::Aggressive),
+            1
+        );
     }
 
     #[test]

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,0 +1,131 @@
+use crate::{RbmemDocument, RbmemError};
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum ExportFormat {
+    Dot,
+    Mermaid,
+    Cytoscape,
+    Gexf,
+}
+
+pub fn export_graph(document: &RbmemDocument, format: ExportFormat) -> Result<String, RbmemError> {
+    match format {
+        ExportFormat::Dot => Ok(document.graph_as_dot()),
+        ExportFormat::Mermaid => Ok(export_mermaid(document)),
+        ExportFormat::Cytoscape => Ok(serde_json::to_string_pretty(&export_cytoscape(document))?),
+        ExportFormat::Gexf => Ok(export_gexf(document)),
+    }
+}
+
+fn export_mermaid(document: &RbmemDocument) -> String {
+    let view = document.graph_view();
+    let mut output = String::from("graph TD\n");
+    for node in &view.nodes {
+        output.push_str(&format!("  {}\n", mermaid_node(node)));
+    }
+    for edge in &view.edges {
+        output.push_str(&format!(
+            "  {} -->|{}| {}\n",
+            mermaid_node(&edge.from),
+            escape_mermaid(&edge.edge_type),
+            mermaid_node(&edge.to)
+        ));
+    }
+    output
+}
+
+fn export_cytoscape(document: &RbmemDocument) -> serde_json::Value {
+    let view = document.graph_view();
+    let nodes = view
+        .nodes
+        .iter()
+        .map(|node| json!({ "data": { "id": node, "label": node } }))
+        .collect::<Vec<_>>();
+    let edges = view
+        .edges
+        .iter()
+        .enumerate()
+        .map(|(index, edge)| {
+            json!({
+                "data": {
+                    "id": format!("e{index}"),
+                    "source": edge.from,
+                    "target": edge.to,
+                    "label": edge.edge_type,
+                    "type": edge.edge_type,
+                    "inferred": edge.inferred,
+                    "confidence": edge.confidence,
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!({ "elements": { "nodes": nodes, "edges": edges } })
+}
+
+fn export_gexf(document: &RbmemDocument) -> String {
+    let view = document.graph_view();
+    let mut output = String::from(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<gexf version="1.3">
+  <graph mode="static" defaultedgetype="directed">
+    <nodes>
+"#,
+    );
+    for (index, node) in view.nodes.iter().enumerate() {
+        output.push_str(&format!(
+            "      <node id=\"{}\" label=\"{}\" />\n",
+            index,
+            escape_xml(node)
+        ));
+    }
+    output.push_str("    </nodes>\n    <edges>\n");
+    for (index, edge) in view.edges.iter().enumerate() {
+        let source = view
+            .nodes
+            .iter()
+            .position(|node| node == &edge.from)
+            .unwrap_or(0);
+        let target = view
+            .nodes
+            .iter()
+            .position(|node| node == &edge.to)
+            .unwrap_or(0);
+        output.push_str(&format!(
+            "      <edge id=\"{}\" source=\"{}\" target=\"{}\" label=\"{}\" />\n",
+            index,
+            source,
+            target,
+            escape_xml(&edge.edge_type)
+        ));
+    }
+    output.push_str("    </edges>\n  </graph>\n</gexf>\n");
+    output
+}
+
+fn mermaid_node(value: &str) -> String {
+    format!("{}[\"{}\"]", stable_id(value), escape_mermaid(value))
+}
+
+fn stable_id(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+        .collect()
+}
+
+fn escape_mermaid(value: &str) -> String {
+    value.replace('"', "'")
+}
+
+fn escape_xml(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,180 @@
+use crate::RbmemDocument;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fs;
+use std::path::Path;
+use std::time::SystemTime;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SectionIndex {
+    keywords: BTreeMap<String, BTreeSet<String>>,
+    paths: Vec<String>,
+    adjacency: BTreeMap<String, BTreeSet<String>>,
+    trie: PathTrie,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct PathTrie {
+    terminal: bool,
+    children: BTreeMap<String, PathTrie>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CachedSectionIndex {
+    pub modified_at: SystemTime,
+    pub index: SectionIndex,
+}
+
+impl SectionIndex {
+    pub fn build(document: &RbmemDocument) -> Self {
+        let mut keywords: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        let mut paths = Vec::new();
+        let mut trie = PathTrie::default();
+        let mut adjacency: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+
+        for section in &document.sections {
+            paths.push(section.path.clone());
+            trie.insert(&section.path);
+            for token in tokenize(&format!("{} {}", section.path, section.content)) {
+                keywords
+                    .entry(token)
+                    .or_default()
+                    .insert(section.path.clone());
+            }
+        }
+
+        for edge in document.graph_view().edges {
+            adjacency
+                .entry(edge.from.clone())
+                .or_default()
+                .insert(edge.to.clone());
+            adjacency.entry(edge.to).or_default().insert(edge.from);
+        }
+
+        paths.sort();
+        Self {
+            keywords,
+            paths,
+            adjacency,
+            trie,
+        }
+    }
+
+    pub fn keyword(&self, keyword: &str) -> Vec<String> {
+        self.keywords
+            .get(&normalize_token(keyword))
+            .into_iter()
+            .flat_map(|paths| paths.iter().cloned())
+            .collect()
+    }
+
+    pub fn prefix(&self, pattern: &str) -> Vec<String> {
+        let prefix = pattern.strip_suffix(".*").unwrap_or(pattern);
+        self.trie.prefix(prefix)
+    }
+
+    pub fn related(&self, path: &str, depth: usize) -> Vec<String> {
+        if depth == 0 {
+            return Vec::new();
+        }
+
+        let mut visited = BTreeSet::from([path.to_string()]);
+        let mut frontier = VecDeque::from([(path.to_string(), 0usize)]);
+        let mut related = BTreeSet::new();
+
+        while let Some((current, current_depth)) = frontier.pop_front() {
+            if current_depth >= depth {
+                continue;
+            }
+            if let Some(neighbors) = self.adjacency.get(&current) {
+                for neighbor in neighbors {
+                    if self.paths.binary_search(neighbor).is_err() {
+                        continue;
+                    }
+                    if visited.insert(neighbor.clone()) {
+                        related.insert(neighbor.clone());
+                        frontier.push_back((neighbor.clone(), current_depth + 1));
+                    }
+                }
+            }
+        }
+
+        related.into_iter().collect()
+    }
+
+    pub fn save_disk_cache(&self, path: impl AsRef<Path>) -> Result<(), crate::RbmemError> {
+        fs::write(path, serde_json::to_string(self)?)?;
+        Ok(())
+    }
+
+    pub fn load_disk_cache(path: impl AsRef<Path>) -> Result<Self, crate::RbmemError> {
+        Ok(serde_json::from_str(&fs::read_to_string(path)?)?)
+    }
+}
+
+impl CachedSectionIndex {
+    pub fn load_or_rebuild(
+        memory_path: impl AsRef<Path>,
+        document: &RbmemDocument,
+    ) -> Result<Self, crate::RbmemError> {
+        let memory_path = memory_path.as_ref();
+        let modified_at = fs::metadata(memory_path)?.modified()?;
+        Ok(Self {
+            modified_at,
+            index: SectionIndex::build(document),
+        })
+    }
+
+    pub fn is_valid_for(&self, memory_path: impl AsRef<Path>) -> Result<bool, crate::RbmemError> {
+        Ok(fs::metadata(memory_path)?.modified()? == self.modified_at)
+    }
+}
+
+impl PathTrie {
+    fn insert(&mut self, path: &str) {
+        let mut node = self;
+        for segment in path.split('.') {
+            node = node.children.entry(segment.to_string()).or_default();
+        }
+        node.terminal = true;
+    }
+
+    fn prefix(&self, prefix: &str) -> Vec<String> {
+        let mut node = self;
+        for segment in prefix.split('.').filter(|segment| !segment.is_empty()) {
+            let Some(next) = node.children.get(segment) else {
+                return Vec::new();
+            };
+            node = next;
+        }
+
+        let mut output = Vec::new();
+        node.collect(prefix.trim_end_matches('.').to_string(), &mut output);
+        output.sort();
+        output
+    }
+
+    fn collect(&self, prefix: String, output: &mut Vec<String>) {
+        if self.terminal {
+            output.push(prefix.clone());
+        }
+        for (segment, child) in &self.children {
+            let path = if prefix.is_empty() {
+                segment.clone()
+            } else {
+                format!("{prefix}.{segment}")
+            };
+            child.collect(path, output);
+        }
+    }
+}
+
+fn tokenize(text: &str) -> impl Iterator<Item = String> + '_ {
+    text.split(|ch: char| !ch.is_ascii_alphanumeric())
+        .map(normalize_token)
+        .filter(|token| token.len() > 1)
+}
+
+fn normalize_token(token: &str) -> String {
+    token.trim().to_ascii_lowercase()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,37 @@
-//! RBMEM v1.3 library surface.
+//! RBMEM v1.4.0 library surface.
 //!
 //! The binary in `main.rs` is intentionally thin.  Most behavior lives here so
 //! parser and document semantics can be tested without spawning a process.
 
+pub mod commands;
+pub mod crypto;
+pub mod diff;
 pub mod document;
+pub mod export;
+pub mod index;
 pub mod parser;
+pub mod server;
+pub mod version;
 
+pub use commands::{
+    context, context_json, create, decrypt_section, delete_section, diff, diff_documents,
+    diff_file_with_format, encrypt_section, load, query, query_document, read,
+    read_content_argument, render_context_document, render_context_output, save, update,
+    ContextOptions, ContextOutputRequest, CreateOptions, OutputFormat, ReadOptions, UpdateOptions,
+};
+pub use crypto::EncryptionKey;
+pub use diff::{
+    diff_documents_typed, diff_with_format, merge_documents, render_diff_text, DiffFormat,
+    MergeStrategy, RbmemDiff, SectionDiff, SectionDiffKind,
+};
 pub use document::{
-    CompactMode, GraphEdge, GraphRelation, GraphView, Meta, RbmemDocument, RbmemError,
-    ResolvedSection, Section, SectionType, SourceInfo, Temporal, TimestampPolicy,
+    CompactMode, EncryptedPayload, GraphEdge, GraphRelation, GraphView, InferenceStrategy, Meta,
+    RbmemDocument, RbmemError, ResolvedSection, Section, SectionType, SourceInfo, Temporal,
+    TimestampPolicy,
+};
+pub use export::{export_graph, ExportFormat};
+pub use index::{CachedSectionIndex, SectionIndex};
+pub use version::{
+    is_supported_format_version, RBMEM_FORMAT_LABEL, RBMEM_FORMAT_VERSION,
+    RBMEM_LEGACY_FORMAT_VERSION,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use clap::{Parser, Subcommand, ValueEnum};
 use notify::{Config as NotifyConfig, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use rbmem::commands as api;
 use rbmem::document::graph_view_to_json;
 #[cfg(test)]
 use rbmem::document::GraphInfo;
@@ -8,11 +9,13 @@ use rbmem::parser::parse_document;
 #[cfg(test)]
 use rbmem::GraphRelation;
 use rbmem::{
-    CompactMode, RbmemDocument, RbmemError, Section, SectionType, SourceInfo, TimestampPolicy,
+    CompactMode, DiffFormat, InferenceStrategy, MergeStrategy, OutputFormat, RbmemDocument,
+    RbmemError, Section, SectionType, SourceInfo, TimestampPolicy,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
+use std::error::Error;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -20,12 +23,15 @@ use std::process::Command as ProcessCommand;
 use std::str::FromStr;
 use std::sync::mpsc;
 use std::time::SystemTime;
+use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]
 #[command(name = "rbmem")]
 #[command(version)]
-#[command(about = "Rust-Brain Memory Format (.rbmem) v1.3 CLI")]
+#[command(about = "Rust-Brain Memory Format (.rbmem) v1.4.0 CLI")]
 struct Cli {
+    #[arg(long, value_enum, default_value_t = LogFormat::Text, global = true)]
+    log_format: LogFormat,
     #[command(subcommand)]
     command: Command,
 }
@@ -43,6 +49,13 @@ enum Command {
         #[arg(long)]
         human: bool,
     },
+    DeleteSection {
+        file: PathBuf,
+        #[arg(long)]
+        section: String,
+        #[arg(long)]
+        dry_run: bool,
+    },
     Read {
         file: PathBuf,
         #[arg(long)]
@@ -53,6 +66,8 @@ enum Command {
         minified: bool,
         #[arg(long)]
         hide_empty_temporal: bool,
+        #[arg(long)]
+        decrypt: bool,
         #[arg(long)]
         hermes: bool,
         #[arg(long)]
@@ -79,6 +94,8 @@ enum Command {
         content_file: Option<PathBuf>,
         #[arg(long)]
         human: bool,
+        #[arg(long)]
+        dry_run: bool,
     },
     Prune {
         file: PathBuf,
@@ -87,6 +104,11 @@ enum Command {
         file: PathBuf,
         #[arg(long, value_enum, default_value_t = GraphFormat::Json)]
         format: GraphFormat,
+    },
+    Export {
+        file: PathBuf,
+        #[arg(long, value_enum)]
+        format: rbmem::ExportFormat,
     },
     Tree {
         file: PathBuf,
@@ -101,11 +123,15 @@ enum Command {
         infer_relations: bool,
         #[arg(long, default_value_t = 0.6)]
         min_confidence: f64,
+        #[arg(long, value_enum, default_value_t = InferenceStrategy::Balanced)]
+        inference_strategy: InferenceStrategy,
     },
     Infer {
         file: PathBuf,
         #[arg(long, default_value_t = 0.6)]
         min_confidence: f64,
+        #[arg(long, value_enum, default_value_t = InferenceStrategy::Balanced)]
+        inference_strategy: InferenceStrategy,
     },
     Query {
         file: PathBuf,
@@ -120,6 +146,8 @@ enum Command {
         graph_depth: usize,
         #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
         format: OutputFormat,
+        #[arg(long)]
+        decrypt: bool,
     },
     Context {
         file: PathBuf,
@@ -135,10 +163,40 @@ enum Command {
         graph_depth: usize,
         #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
         format: OutputFormat,
+        #[arg(long)]
+        decrypt: bool,
+    },
+    Encrypt {
+        file: PathBuf,
+        #[arg(long)]
+        section: String,
+    },
+    Decrypt {
+        file: PathBuf,
+        #[arg(long)]
+        section: String,
     },
     Diff {
         before: PathBuf,
         after: PathBuf,
+        #[arg(long, value_enum, default_value_t = DiffFormat::Text)]
+        format: DiffFormat,
+    },
+    Merge {
+        base: PathBuf,
+        local: PathBuf,
+        remote: PathBuf,
+        #[arg(long, value_enum, default_value_t = MergeStrategy::Manual)]
+        strategy: MergeStrategy,
+        #[arg(long)]
+        output: Option<PathBuf>,
+    },
+    Migrate {
+        file: PathBuf,
+        #[arg(long)]
+        output: Option<PathBuf>,
+        #[arg(long)]
+        dry_run: bool,
     },
     Review {
         file: PathBuf,
@@ -171,8 +229,16 @@ enum Command {
         infer_relations: bool,
         #[arg(long, default_value_t = 0.6)]
         min_confidence: f64,
+        #[arg(long, value_enum, default_value_t = InferenceStrategy::Balanced)]
+        inference_strategy: InferenceStrategy,
         #[arg(long)]
         dry_run: bool,
+    },
+    Serve {
+        #[arg(long, default_value = "localhost:3000")]
+        bind: String,
+        #[arg(long)]
+        dir: PathBuf,
     },
     Hermes {
         #[command(subcommand)]
@@ -197,7 +263,9 @@ enum HermesCommand {
     Save {
         file: PathBuf,
         #[arg(long)]
-        json: String,
+        json: Option<String>,
+        #[arg(long)]
+        json_file: Option<PathBuf>,
     },
     Init {
         project_name: String,
@@ -221,20 +289,42 @@ enum GraphFormat {
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
-enum OutputFormat {
+enum LogFormat {
     Text,
     Json,
+}
+
+fn init_tracing(format: LogFormat) {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"));
+    let result = match format {
+        LogFormat::Text => tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .without_time()
+            .try_init(),
+        LogFormat::Json => tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .json()
+            .try_init(),
+    };
+    let _ = result;
 }
 
 fn main() {
     if let Err(error) = run() {
         eprintln!("error: {error}");
+        let mut source = error.source();
+        while let Some(error) = source {
+            eprintln!("caused by: {error}");
+            source = error.source();
+        }
         std::process::exit(1);
     }
 }
 
 fn run() -> Result<(), RbmemError> {
     let cli = Cli::parse();
+    init_tracing(cli.log_format);
+    tracing::info!(command = ?cli.command, "rbmem_command_start");
 
     match cli.command {
         Command::Create {
@@ -245,10 +335,16 @@ fn run() -> Result<(), RbmemError> {
             human,
         } => {
             let now = Utc::now();
-            let mut document = RbmemDocument::new(now, created_by);
-            document.meta.purpose = purpose;
-            document.meta.default_expiry_days = default_expiry_days;
-            write_document(&file, &document, human)?;
+            api::create(
+                &file,
+                api::CreateOptions {
+                    created_by,
+                    purpose,
+                    default_expiry_days,
+                    human,
+                    now,
+                },
+            )?;
             println!("created {}", file.display());
         }
         Command::Read {
@@ -257,36 +353,40 @@ fn run() -> Result<(), RbmemError> {
             compact,
             minified,
             hide_empty_temporal,
+            decrypt,
             hermes,
             hermes_inject,
         } => {
-            let document = read_document(&file, TimestampPolicy::Preserve)?;
             if hermes_inject {
+                let document = api::load(&file, TimestampPolicy::Preserve)?;
                 print!(
                     "{}",
                     hermes_inject_block(&document, resolve, compact, minified)?
                 );
             } else if hermes {
+                let document = api::load(&file, TimestampPolicy::Preserve)?;
                 println!(
                     "{}",
                     serde_json::to_string_pretty(&hermes_json(
                         &document, resolve, compact, minified
                     )?)?
                 );
-            } else if minified
-                || (resolve && !compact && document.meta.compact_mode == CompactMode::Minified)
-            {
-                print!("{}", document.to_minified_string(resolve));
-            } else if compact || (resolve && document.meta.compact_mode == CompactMode::Compact) {
-                print!("{}", document.to_compact_string(resolve, Utc::now()));
-            } else if resolve {
-                for section in document.resolved_sections() {
-                    println!("[{}] type={}", section.path, section.section_type);
-                    println!("{}", section.content);
-                    println!();
-                }
             } else {
-                print_full_document(&document, hide_empty_temporal);
+                print!(
+                    "{}",
+                    api::read(
+                        &file,
+                        api::ReadOptions {
+                            resolve,
+                            compact,
+                            minified,
+                            hide_empty_temporal,
+                            decrypt,
+                            key: None,
+                            policy: TimestampPolicy::Preserve,
+                        },
+                    )?
+                );
             }
         }
         Command::Resolve {
@@ -316,28 +416,39 @@ fn run() -> Result<(), RbmemError> {
             content,
             content_file,
             human,
+            dry_run,
         } => {
             let now = Utc::now();
-            let mut document = if file.exists() {
-                read_document(&file, TimestampPolicy::Preserve)?
-            } else {
-                RbmemDocument::new(now, "me")
-            };
             let section_type = SectionType::from_str(&r#type)?;
-            let body = read_content_argument(content, content_file)?;
-            document.upsert_section(&section, section_type, body, now);
-            set_section_source(
-                &mut document,
-                &section,
-                SourceInfo {
-                    kind: "cli".to_string(),
-                    path: None,
-                    actor: Some("me".to_string()),
+            let body = api::read_content_argument(content, content_file)?;
+            api::update(
+                &file,
+                api::UpdateOptions {
+                    section,
+                    section_type,
+                    content: body,
+                    human,
+                    dry_run,
+                    now,
                 },
-            );
-            document.enforce_protected_timestamps(now);
-            write_document(&file, &document, human)?;
-            println!("updated {}", file.display());
+            )?;
+            if dry_run {
+                println!("would update {}", file.display());
+            } else {
+                println!("updated {}", file.display());
+            }
+        }
+        Command::DeleteSection {
+            file,
+            section,
+            dry_run,
+        } => {
+            api::delete_section(&file, &section, dry_run, Utc::now())?;
+            if dry_run {
+                println!("would delete {}#{}", file.display(), section);
+            } else {
+                println!("deleted {}#{}", file.display(), section);
+            }
         }
         Command::Prune { file } => {
             let now = Utc::now();
@@ -356,6 +467,10 @@ fn run() -> Result<(), RbmemError> {
                 GraphFormat::Dot => print!("{}", document.graph_as_dot()),
             }
         }
+        Command::Export { file, format } => {
+            let document = read_document(&file, TimestampPolicy::Preserve)?;
+            print!("{}", rbmem::export_graph(&document, format)?);
+        }
         Command::Tree { file } => {
             let document = read_document(&file, TimestampPolicy::Preserve)?;
             print!("{}", document.tree());
@@ -365,7 +480,7 @@ fn run() -> Result<(), RbmemError> {
             let mut warnings = parsed.warnings;
             warnings.extend(parsed.document.validate());
             if warnings.is_empty() {
-                println!("valid RBMEM v1.3");
+                println!("valid RBMEM v1.4.0");
             } else {
                 for warning in warnings {
                     println!("warning: {warning}");
@@ -377,20 +492,22 @@ fn run() -> Result<(), RbmemError> {
             output,
             infer_relations,
             min_confidence,
+            inference_strategy,
         } => {
             let now = Utc::now();
             let text = fs::read_to_string(&markdown)?;
             let mut document = convert_markdown_to_rbmem(&text, now);
             stamp_document_source(
                 &mut document,
-                SourceInfo {
-                    kind: "markdown".to_string(),
-                    path: Some(markdown.display().to_string()),
-                    actor: Some("sync".to_string()),
-                },
+                source_info(
+                    "markdown",
+                    Some(markdown.display().to_string()),
+                    "sync",
+                    Some(&text),
+                ),
             );
             if infer_relations {
-                document.infer_relations(now, min_confidence);
+                document.infer_relations_with_strategy(now, min_confidence, inference_strategy);
             }
             write_document(&output, &document, false)?;
             println!("converted {} -> {}", markdown.display(), output.display());
@@ -398,10 +515,12 @@ fn run() -> Result<(), RbmemError> {
         Command::Infer {
             file,
             min_confidence,
+            inference_strategy,
         } => {
             let now = Utc::now();
             let mut document = read_document(&file, TimestampPolicy::Preserve)?;
-            let added = document.infer_relations(now, min_confidence);
+            let added =
+                document.infer_relations_with_strategy(now, min_confidence, inference_strategy);
             write_document(&file, &document, false)?;
             println!("added {added} inferred relation(s)");
         }
@@ -413,24 +532,28 @@ fn run() -> Result<(), RbmemError> {
             minified,
             graph_depth,
             format,
+            decrypt,
         } => {
-            let document = read_document(&file, TimestampPolicy::Preserve)?;
-            let context = query_document(&document, &text, resolve, graph_depth);
-            print_context_output(
-                ContextOutputRequest {
-                    operation: "query",
-                    file: &file,
-                    selector_name: "text",
-                    selector_value: &text,
-                    resolve,
-                    compact,
-                    minified,
-                    graph_depth,
-                    format,
-                },
-                &document,
-                &context,
-            )?;
+            print!(
+                "{}",
+                api::query(
+                    &file,
+                    &text,
+                    api::ContextOptions {
+                        resolve,
+                        compact,
+                        minified,
+                        graph_depth,
+                        decrypt,
+                        key: None,
+                        format,
+                        policy: TimestampPolicy::Preserve,
+                    },
+                )?
+            );
+            if format == OutputFormat::Json {
+                println!();
+            }
         }
         Command::Context {
             file,
@@ -440,29 +563,103 @@ fn run() -> Result<(), RbmemError> {
             minified,
             graph_depth,
             format,
+            decrypt,
         } => {
-            let document = read_document(&file, TimestampPolicy::Preserve)?;
-            let context = query_document(&document, &task, resolve, graph_depth);
-            print_context_output(
-                ContextOutputRequest {
-                    operation: "context",
-                    file: &file,
-                    selector_name: "task",
-                    selector_value: &task,
-                    resolve,
-                    compact,
-                    minified,
-                    graph_depth,
-                    format,
-                },
-                &document,
-                &context,
-            )?;
+            print!(
+                "{}",
+                api::context(
+                    &file,
+                    &task,
+                    api::ContextOptions {
+                        resolve,
+                        compact,
+                        minified,
+                        graph_depth,
+                        decrypt,
+                        key: None,
+                        format,
+                        policy: TimestampPolicy::Preserve,
+                    },
+                )?
+            );
+            if format == OutputFormat::Json {
+                println!();
+            }
         }
-        Command::Diff { before, after } => {
-            let before = read_document(&before, TimestampPolicy::Preserve)?;
-            let after = read_document(&after, TimestampPolicy::Preserve)?;
-            print!("{}", diff_documents(&before, &after));
+        Command::Encrypt { file, section } => {
+            let key = rbmem::EncryptionKey::resolve()?;
+            api::encrypt_section(&file, &section, &key, Utc::now())?;
+            println!("encrypted {}#{}", file.display(), section);
+        }
+        Command::Decrypt { file, section } => {
+            let key = rbmem::EncryptionKey::resolve()?;
+            api::decrypt_section(&file, &section, &key, Utc::now())?;
+            println!("decrypted {}#{}", file.display(), section);
+        }
+        Command::Diff {
+            before,
+            after,
+            format,
+        } => {
+            print!("{}", api::diff_file_with_format(&before, &after, format)?);
+        }
+        Command::Merge {
+            base,
+            local,
+            remote,
+            strategy,
+            output,
+        } => {
+            let base_document = api::load(&base, TimestampPolicy::Preserve)?;
+            let local_document = api::load(&local, TimestampPolicy::Preserve)?;
+            let remote_document = api::load(&remote, TimestampPolicy::Preserve)?;
+            let merged = rbmem::merge_documents(
+                &base_document,
+                &local_document,
+                &remote_document,
+                strategy,
+                Utc::now(),
+            );
+            if let Some(output) = output {
+                api::save(&output, &merged, false)?;
+                println!("merged {}", output.display());
+            } else {
+                print!("{}", merged.to_rbmem_string());
+            }
+        }
+        Command::Migrate {
+            file,
+            output,
+            dry_run,
+        } => {
+            let raw = fs::read_to_string(&file)?;
+            let parsed = parse_document(&raw, TimestampPolicy::Preserve)?;
+            let target = output.unwrap_or_else(|| file.clone());
+            let source_version = parsed
+                .document
+                .meta
+                .source_version
+                .clone()
+                .unwrap_or_else(|| parsed.document.meta.version.clone());
+            if dry_run {
+                println!(
+                    "would migrate {} from RBMEM {} to RBMEM 1.4.0",
+                    file.display(),
+                    source_version
+                );
+                for warning in parsed.warnings {
+                    println!("warning: {warning}");
+                }
+                print!("{}", parsed.document.to_rbmem_string());
+            } else {
+                write_document(&target, &parsed.document, false)?;
+                println!(
+                    "migrated {} -> {} from RBMEM {} to RBMEM 1.4.0",
+                    file.display(),
+                    target.display(),
+                    source_version
+                );
+            }
         }
         Command::Review { file } => {
             let text = fs::read_to_string(&file)?;
@@ -510,18 +707,25 @@ fn run() -> Result<(), RbmemError> {
             watch,
             infer_relations,
             min_confidence,
+            inference_strategy,
             dry_run,
         } => {
             let options = SyncOptions::from_folder(
                 &markdown_folder,
                 infer_relations,
                 min_confidence,
+                inference_strategy,
                 dry_run,
             )?;
             sync_markdown_folder(&markdown_folder, &output_folder, &options)?;
             if watch {
                 watch_markdown_folder(markdown_folder, output_folder, options)?;
             }
+        }
+        Command::Serve { bind, dir } => {
+            tokio::runtime::Runtime::new()
+                .map_err(RbmemError::Io)?
+                .block_on(rbmem::server::serve(&bind, dir))?;
         }
         Command::Hermes { command } => match command {
             HermesCommand::Load {
@@ -538,14 +742,18 @@ fn run() -> Result<(), RbmemError> {
                     )?)?
                 );
             }
-            HermesCommand::Save { file, json } => {
+            HermesCommand::Save {
+                file,
+                json,
+                json_file,
+            } => {
                 let now = Utc::now();
                 let mut document = if file.exists() {
                     read_document(&file, TimestampPolicy::Preserve)?
                 } else {
                     RbmemDocument::new(now, "hermes")
                 };
-                let payload = read_hermes_payload(&json)?;
+                let payload = read_hermes_payload(json, json_file)?;
                 apply_hermes_payload(&mut document, payload, now)?;
                 write_document(&file, &document, false)?;
                 validate_or_error(&document)?;
@@ -601,28 +809,6 @@ fn write_document(path: &Path, document: &RbmemDocument, human: bool) -> Result<
     };
     fs::write(path, text)?;
     Ok(())
-}
-
-fn print_full_document(document: &RbmemDocument, hide_empty_temporal: bool) {
-    if hide_empty_temporal {
-        print!("{}", document.to_rbmem_string_hiding_empty_temporal());
-    } else {
-        print!("{}", document.to_rbmem_string());
-    }
-}
-
-fn read_content_argument(
-    content: Option<String>,
-    content_file: Option<PathBuf>,
-) -> Result<String, RbmemError> {
-    match (content, content_file) {
-        (Some(content), None) => Ok(content),
-        (None, Some(path)) => Ok(fs::read_to_string(path)?),
-        (None, None) => Ok(String::new()),
-        (Some(_), Some(_)) => Err(RbmemError::Parse(
-            "use either --content or --content-file, not both".to_string(),
-        )),
-    }
 }
 
 fn convert_markdown_to_rbmem(markdown: &str, now: chrono::DateTime<Utc>) -> RbmemDocument {
@@ -684,14 +870,12 @@ fn title_to_path(title: &str) -> String {
             slug.push(ch.to_ascii_lowercase());
             last_was_separator = false;
         } else if !last_was_separator && !slug.is_empty() {
-            // Spaces and punctuation belong inside the current heading segment.
-            // Dots are reserved for real Markdown heading depth.
-            slug.push('-');
+            slug.push('.');
             last_was_separator = true;
         }
     }
 
-    while slug.ends_with('-') {
+    while slug.ends_with('.') {
         slug.pop();
     }
 
@@ -945,6 +1129,29 @@ fn stamp_document_source(document: &mut RbmemDocument, source: SourceInfo) {
     }
 }
 
+fn source_info(
+    kind: impl Into<String>,
+    path: Option<String>,
+    actor: impl Into<String>,
+    hash_input: Option<&str>,
+) -> SourceInfo {
+    SourceInfo {
+        kind: kind.into(),
+        path,
+        actor: Some(actor.into()),
+        hash: hash_input.map(sha256_hex),
+    }
+}
+
+fn sha256_hex(input: &str) -> String {
+    let digest = ring::digest::digest(&ring::digest::SHA256, input.as_bytes());
+    let mut output = String::from("sha256:");
+    for byte in digest.as_ref() {
+        output.push_str(&format!("{byte:02x}"));
+    }
+    output
+}
+
 fn set_section_source(document: &mut RbmemDocument, path: &str, source: SourceInfo) {
     if let Some(section) = document
         .sections
@@ -955,69 +1162,12 @@ fn set_section_source(document: &mut RbmemDocument, path: &str, source: SourceIn
     }
 }
 
-fn diff_documents(before: &RbmemDocument, after: &RbmemDocument) -> String {
-    let before_by_path = section_map(before);
-    let after_by_path = section_map(after);
-    let mut output = String::new();
-
-    for path in after_by_path.keys() {
-        if !before_by_path.contains_key(path) {
-            output.push_str(&format!("added: {path}\n"));
-        }
-    }
-
-    for path in before_by_path.keys() {
-        if !after_by_path.contains_key(path) {
-            output.push_str(&format!("removed: {path}\n"));
-        }
-    }
-
-    for path in after_by_path.keys() {
-        let Some(before_section) = before_by_path.get(path) else {
-            continue;
-        };
-        let after_section = after_by_path[path];
-        if before_section.section_type != after_section.section_type {
-            output.push_str(&format!(
-                "changed type: {path} {} -> {}\n",
-                before_section.section_type, after_section.section_type
-            ));
-        }
-        if before_section.content != after_section.content {
-            output.push_str(&format!("changed content: {path}\n"));
-        }
-        if before_section.temporal != after_section.temporal {
-            output.push_str(&format!("changed temporal: {path}\n"));
-        }
-        if before_section.source != after_section.source {
-            output.push_str(&format!("changed source: {path}\n"));
-        }
-        if before_section.graph != after_section.graph {
-            output.push_str(&format!("changed graph: {path}\n"));
-        }
-    }
-
-    if output.is_empty() {
-        "no RBMEM differences\n".to_string()
-    } else {
-        output
-    }
-}
-
-fn section_map(document: &RbmemDocument) -> HashMap<String, &Section> {
-    document
-        .sections
-        .iter()
-        .map(|section| (section.path.clone(), section))
-        .collect()
-}
-
 fn review_document(document: &RbmemDocument, mut warnings: Vec<String>) -> String {
     warnings.extend(document.validate());
     let mut output = String::new();
 
     if warnings.is_empty() {
-        output.push_str("valid RBMEM v1.3\n");
+        output.push_str("valid RBMEM v1.4.0\n");
     } else {
         for warning in warnings {
             output.push_str(&format!("warning: {warning}\n"));
@@ -1066,7 +1216,7 @@ fn doctor_text_report(file: Option<&Path>) -> Result<String, RbmemError> {
         "cli-version: rbmem {}\n",
         env!("CARGO_PKG_VERSION")
     ));
-    output.push_str("document-format: RBMEM v1.3\n");
+    output.push_str("document-format: RBMEM v1.4.0\n");
 
     if let Some(file) = file {
         append_document_diagnostics(&mut output, file)?;
@@ -1130,7 +1280,7 @@ fn doctor_json(file: Option<&Path>) -> Result<Value, RbmemError> {
     Ok(json!({
         "schema": "rbmem.doctor.v1",
         "cli_version": format!("rbmem {}", env!("CARGO_PKG_VERSION")),
-        "document_format": "RBMEM v1.3",
+        "document_format": "RBMEM v1.4.0",
         "document": document,
     }))
 }
@@ -1345,6 +1495,7 @@ fn pack_document(
 struct SyncOptions {
     infer_relations: bool,
     min_confidence: f64,
+    inference_strategy: InferenceStrategy,
     dry_run: bool,
     default_expiry_days: Option<i64>,
     compact_mode: CompactMode,
@@ -1355,11 +1506,13 @@ impl SyncOptions {
         markdown_folder: &Path,
         infer_relations: bool,
         min_confidence: f64,
+        inference_strategy: InferenceStrategy,
         dry_run: bool,
     ) -> Result<Self, RbmemError> {
         let mut options = Self {
             infer_relations,
             min_confidence: min_confidence.clamp(0.0, 1.0),
+            inference_strategy,
             dry_run,
             default_expiry_days: None,
             compact_mode: CompactMode::Full,
@@ -1396,6 +1549,9 @@ fn apply_sync_config(text: &str, options: &mut SyncOptions) -> Result<(), RbmemE
                 if let Ok(confidence) = value.parse::<f64>() {
                     options.min_confidence = confidence.clamp(0.0, 1.0);
                 }
+            }
+            "inference_strategy" => {
+                options.inference_strategy = <InferenceStrategy as FromStr>::from_str(value)?;
             }
             "default_expiry_days" => {
                 options.default_expiry_days = if value.eq_ignore_ascii_case("null") {
@@ -1498,14 +1654,14 @@ fn sync_markdown_file(
         .to_string();
     stamp_document_source(
         &mut document,
-        SourceInfo {
-            kind: "markdown".to_string(),
-            path: Some(source_path),
-            actor: Some("sync".to_string()),
-        },
+        source_info("markdown", Some(source_path), "sync", Some(&markdown)),
     );
     if options.infer_relations {
-        document.infer_relations(now, options.min_confidence);
+        document.infer_relations_with_strategy(
+            now,
+            options.min_confidence,
+            options.inference_strategy,
+        );
     }
 
     if let Some(parent) = output_file.parent() {
@@ -1637,6 +1793,7 @@ fn notify_error(error: notify::Error) -> RbmemError {
 fn document_meta_json(document: &RbmemDocument) -> Value {
     json!({
         "version": document.meta.version,
+        "source_version": document.meta.source_version,
         "purpose": document.meta.purpose,
         "compact_mode": document.meta.compact_mode.to_string(),
         "last_updated": document.meta.last_updated,
@@ -1768,11 +1925,23 @@ fn default_text_type() -> String {
     "text".to_string()
 }
 
-fn read_hermes_payload(input: &str) -> Result<HermesPayload, RbmemError> {
-    let text = if Path::new(input).exists() {
-        fs::read_to_string(input)?
-    } else {
-        input.to_string()
+fn read_hermes_payload(
+    json: Option<String>,
+    json_file: Option<PathBuf>,
+) -> Result<HermesPayload, RbmemError> {
+    let text = match (json, json_file) {
+        (Some(_), Some(_)) => {
+            return Err(RbmemError::Parse(
+                "use either --json or --json-file, not both".to_string(),
+            ))
+        }
+        (Some(json), None) => json,
+        (None, Some(path)) => fs::read_to_string(path)?,
+        (None, None) => {
+            return Err(RbmemError::Parse(
+                "missing --json or --json-file".to_string(),
+            ))
+        }
     };
     Ok(serde_json::from_str(&text)?)
 }
@@ -1784,6 +1953,12 @@ fn apply_hermes_payload(
 ) -> Result<(), RbmemError> {
     for patch in payload.sections {
         let section_type = SectionType::from_str(&patch.r#type)?;
+        if section_type == SectionType::HermesMemory && patch.mode == HermesWriteMode::Replace {
+            return Err(RbmemError::Parse(format!(
+                "hermes:memory section '{}' is append-only; use mode auto or append",
+                patch.path
+            )));
+        }
         let should_append = patch.mode == HermesWriteMode::Append
             || (patch.mode == HermesWriteMode::Auto && section_type == SectionType::HermesMemory);
 
@@ -1799,6 +1974,7 @@ fn apply_hermes_payload(
                 kind: "hermes".to_string(),
                 path: None,
                 actor: Some("hermes".to_string()),
+                hash: None,
             }),
         );
     }
@@ -1990,7 +2166,7 @@ Body.
 
         assert_eq!(
             paths,
-            vec!["inhibition-of-return.how-it-works.theoretical-mechanisms"]
+            vec!["inhibition.of.return.how.it.works.theoretical.mechanisms"]
         );
     }
 
@@ -2029,7 +2205,9 @@ Body.
         .unwrap();
         fs::write(markdown.join(".rbmemsync"), "compact_mode: minified\n").unwrap();
 
-        let options = SyncOptions::from_folder(&markdown, false, 0.6, false).unwrap();
+        let options =
+            SyncOptions::from_folder(&markdown, false, 0.6, InferenceStrategy::Balanced, false)
+                .unwrap();
         sync_markdown_folder(&markdown, &output, &options).unwrap();
 
         let generated = output.join("concepts").join("agent.rbmem");
@@ -2049,6 +2227,10 @@ Body.
         assert_eq!(source.kind, "markdown");
         let expected_source_path = Path::new("concepts").join("agent.md").display().to_string();
         assert_eq!(source.path.as_deref(), Some(expected_source_path.as_str()));
+        assert!(source
+            .hash
+            .as_ref()
+            .is_some_and(|hash| hash.starts_with("sha256:")));
 
         let _ = fs::remove_dir_all(root);
     }
@@ -2061,7 +2243,9 @@ Body.
         fs::create_dir_all(&markdown).unwrap();
         fs::write(markdown.join("note.md"), "# Note\n\nBody.").unwrap();
 
-        let options = SyncOptions::from_folder(&markdown, false, 0.6, true).unwrap();
+        let options =
+            SyncOptions::from_folder(&markdown, false, 0.6, InferenceStrategy::Balanced, true)
+                .unwrap();
         sync_markdown_folder(&markdown, &output, &options).unwrap();
 
         assert!(!output.join("note.rbmem").exists());
@@ -2076,7 +2260,9 @@ Body.
         fs::create_dir_all(&markdown).unwrap();
         fs::write(markdown.join("note.md"), "# Note\n\nBody.").unwrap();
 
-        let options = SyncOptions::from_folder(&markdown, false, 0.6, false).unwrap();
+        let options =
+            SyncOptions::from_folder(&markdown, false, 0.6, InferenceStrategy::Balanced, false)
+                .unwrap();
         sync_markdown_folder(&markdown, &output, &options).unwrap();
         let generated = output.join("note.rbmem");
         let first_modified = fs::metadata(&generated).unwrap().modified().unwrap();
@@ -2184,7 +2370,7 @@ Body.
         after.upsert_section("rules", SectionType::Text, "new".to_string(), now);
         after.upsert_section("memory", SectionType::Text, "added".to_string(), now);
 
-        let diff = diff_documents(&before, &after);
+        let diff = api::diff_documents(&before, &after);
 
         assert!(diff.contains("added: memory"));
         assert!(diff.contains("changed content: rules"));
@@ -2209,6 +2395,7 @@ Body.
             kind: "hermes".to_string(),
             path: None,
             actor: Some("hermes".to_string()),
+            hash: None,
         });
         memory.graph = Some(GraphInfo {
             node_type: None,
@@ -2240,7 +2427,7 @@ Body.
 
         assert!(report.contains("rbmem doctor"));
         assert!(report.contains("cli-version: rbmem"));
-        assert!(report.contains("document-format: RBMEM v1.3"));
+        assert!(report.contains("document-format: RBMEM v1.4.0"));
         assert!(report.contains("file-exists: ok"));
         assert!(report.contains("parse: ok"));
         assert!(report.contains("validation: ok"));
@@ -2372,7 +2559,8 @@ include:
         let now = fixed_time();
         let mut document = hermes_starter_document("Demo Project", now);
         let payload = read_hermes_payload(
-            r#"{
+            Some(
+                r#"{
               "sections": [
                 {
                   "path": "memory",
@@ -2381,7 +2569,10 @@ include:
                   "mode": "auto"
                 }
               ]
-            }"#,
+            }"#
+                .to_string(),
+            ),
+            None,
         )
         .unwrap();
 
@@ -2389,7 +2580,8 @@ include:
         apply_hermes_payload(
             &mut document,
             read_hermes_payload(
-                r#"{"sections":[{"path":"memory","type":"hermes:memory","content":"- User prefers compact context."}]}"#,
+                Some(r#"{"sections":[{"path":"memory","type":"hermes:memory","content":"- User prefers compact context."}]}"#.to_string()),
+                None,
             )
             .unwrap(),
             now,
@@ -2409,6 +2601,24 @@ include:
             1
         );
         assert_eq!(memory.section_type, SectionType::HermesMemory);
+    }
+
+    #[test]
+    fn hermes_save_rejects_replace_for_append_only_memory() {
+        let now = fixed_time();
+        let mut document = hermes_starter_document("Demo Project", now);
+        let payload = read_hermes_payload(
+            Some(
+                r#"{"sections":[{"path":"memory","type":"hermes:memory","content":"replacement","mode":"replace"}]}"#
+                    .to_string(),
+            ),
+            None,
+        )
+        .unwrap();
+
+        let error = apply_hermes_payload(&mut document, payload, now).unwrap_err();
+
+        assert!(error.to_string().contains("append-only"));
     }
 
     fn temp_test_dir(name: &str) -> PathBuf {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,13 +1,14 @@
-//! Forgiving Nom parser for RBMEM v1.3.
+//! Forgiving Nom parser for RBMEM v1.4.0.
 //!
 //! This parser is deliberately hand-written and small-function oriented. RBMEM is
 //! meant to survive LLM output, so the parser accepts minor formatting drift,
 //! records warnings, and lets `document.rs` re-emit canonical RBMEM.
 
 use crate::document::{
-    CompactMode, GraphInfo, GraphRelation, Meta, RbmemDocument, RbmemError, Section, SectionType,
-    SourceInfo, Temporal, TimestampPolicy,
+    CompactMode, EncryptedPayload, GraphInfo, GraphRelation, Meta, RbmemDocument, RbmemError,
+    Section, SectionType, SourceInfo, Temporal, TimestampPolicy,
 };
+use crate::version::RBMEM_FORMAT_VERSION;
 use chrono::{DateTime, Utc};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until, take_while1};
@@ -19,7 +20,7 @@ use nom::IResult;
 use std::collections::HashMap;
 use std::str::FromStr;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ParsedDocument {
     pub document: RbmemDocument,
     pub warnings: Vec<String>,
@@ -121,7 +122,14 @@ fn parse_meta(
     if let Some(version) = values.get("version") {
         meta.version = version.clone();
     } else {
-        warnings.push("missing meta.version; defaulted to 1.3".to_string());
+        warnings.push(format!(
+            "missing meta.version; defaulted to {RBMEM_FORMAT_VERSION}"
+        ));
+    }
+    if let Some(source_version) = values.get("_source_version") {
+        if source_version != "null" && !source_version.is_empty() {
+            meta.source_version = Some(source_version.clone());
+        }
     }
 
     if let Some(purpose) = values.get("purpose") {
@@ -173,6 +181,7 @@ struct RawSection {
     temporal_values: HashMap<String, String>,
     source: Option<SourceInfo>,
     graph: Option<GraphInfo>,
+    encrypted_values: HashMap<String, String>,
     content: String,
 }
 
@@ -233,6 +242,7 @@ impl RawSection {
             temporal,
             source: self.source,
             graph: self.graph,
+            encrypted: encrypted_from_values(self.encrypted_values, now, warnings),
             content: self.content,
         }
     }
@@ -294,6 +304,7 @@ fn parse_section_body(path: &str, body: &str) -> RawSection {
     let mut section_type = None;
     let mut temporal_values = HashMap::new();
     let mut source_values = HashMap::new();
+    let mut encrypted_values = HashMap::new();
     let mut graph = GraphInfo::default();
     let mut saw_graph = false;
     let mut content_lines = Vec::new();
@@ -335,6 +346,21 @@ fn parse_section_body(path: &str, body: &str) -> RawSection {
                 content_lines.push(clean_inline_content(inline));
             }
             continue;
+        }
+
+        if mode != BodyMode::Content {
+            if let Some(value) = parse_field_line(trimmed, "nonce") {
+                encrypted_values.insert("nonce".to_string(), value);
+                continue;
+            }
+            if let Some(value) = parse_field_line(trimmed, "ciphertext") {
+                encrypted_values.insert("ciphertext".to_string(), value);
+                continue;
+            }
+            if let Some(value) = parse_field_line(trimmed, "encrypted_at") {
+                encrypted_values.insert("encrypted_at".to_string(), value);
+                continue;
+            }
         }
 
         match mode {
@@ -416,6 +442,7 @@ fn parse_section_body(path: &str, body: &str) -> RawSection {
         temporal_values,
         source: source_from_values(source_values),
         graph: saw_graph.then_some(graph),
+        encrypted_values,
         content: trim_trailing_blank_lines(content_lines).join("\n"),
     }
 }
@@ -440,6 +467,25 @@ fn source_from_values(values: HashMap<String, String>) -> Option<SourceInfo> {
             .get("actor")
             .cloned()
             .filter(|value| !value.is_empty()),
+        hash: values
+            .get("hash")
+            .cloned()
+            .filter(|value| !value.is_empty()),
+    })
+}
+
+fn encrypted_from_values(
+    values: HashMap<String, String>,
+    now: DateTime<Utc>,
+    warnings: &mut Vec<String>,
+) -> Option<EncryptedPayload> {
+    let nonce = values.get("nonce")?.clone();
+    let ciphertext = values.get("ciphertext")?.clone();
+    let encrypted_at = parse_time(values.get("encrypted_at"), now, "encrypted_at", warnings);
+    Some(EncryptedPayload {
+        nonce,
+        ciphertext,
+        encrypted_at,
     })
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,0 +1,345 @@
+use crate::{
+    context_json, export_graph, merge_documents, query_document, render_context_document,
+    ContextOutputRequest, DiffFormat, ExportFormat, MergeStrategy, OutputFormat, RbmemDocument,
+    RbmemError, SectionType, TimestampPolicy,
+};
+use axum::extract::{Path as AxumPath, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+#[derive(Debug, Clone)]
+pub struct AppState {
+    pub dir: PathBuf,
+    memories: Arc<RwLock<HashMap<String, RbmemDocument>>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MemoryCreateRequest {
+    pub name: String,
+    pub created_by: Option<String>,
+    pub purpose: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SectionUpsertRequest {
+    #[serde(default = "default_text_type")]
+    pub section_type: String,
+    #[serde(default)]
+    pub content: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct QueryRequest {
+    pub text: String,
+    #[serde(default)]
+    pub resolve: bool,
+    #[serde(default)]
+    pub compact: bool,
+    #[serde(default)]
+    pub minified: bool,
+    #[serde(default)]
+    pub graph_depth: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DiffRequest {
+    pub other: String,
+    #[serde(default = "default_diff_format")]
+    pub format: DiffFormat,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MergeRequest {
+    pub base: String,
+    pub remote: String,
+    #[serde(default = "default_merge_strategy")]
+    pub strategy: MergeStrategy,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ExportRequest {
+    pub format: ExportFormat,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+impl AppState {
+    pub fn new(dir: PathBuf) -> Self {
+        Self {
+            dir,
+            memories: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    fn memory_path(&self, name: &str) -> PathBuf {
+        let filename = if name.ends_with(".rbmem") {
+            name.to_string()
+        } else {
+            format!("{name}.rbmem")
+        };
+        self.dir.join(filename)
+    }
+}
+
+pub fn app(state: AppState) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/memories", post(create_memory))
+        .route(
+            "/memories/:name",
+            get(get_memory).put(put_memory).delete(delete_memory),
+        )
+        .route(
+            "/memories/:name/sections/:path",
+            get(get_section).put(put_section).delete(delete_section),
+        )
+        .route("/memories/:name/query", post(query_memory))
+        .route("/memories/:name/context", post(context_memory))
+        .route("/memories/:name/diff", post(diff_memory))
+        .route("/memories/:name/merge", post(merge_memory))
+        .route("/memories/:name/export", post(export_memory))
+        .with_state(state)
+}
+
+pub async fn serve(bind: &str, dir: PathBuf) -> Result<(), RbmemError> {
+    let listener = tokio::net::TcpListener::bind(bind).await?;
+    axum::serve(listener, app(AppState::new(dir)))
+        .await
+        .map_err(|error| RbmemError::Io(std::io::Error::other(error)))
+}
+
+async fn health() -> Json<Value> {
+    Json(json!({ "status": "ok" }))
+}
+
+async fn create_memory(
+    State(state): State<AppState>,
+    Json(request): Json<MemoryCreateRequest>,
+) -> Result<Json<RbmemDocument>, (StatusCode, Json<ErrorResponse>)> {
+    let now = Utc::now();
+    let mut document = RbmemDocument::new(now, request.created_by.unwrap_or_else(|| "api".into()));
+    if let Some(purpose) = request.purpose {
+        document.meta.purpose = purpose;
+    }
+    crate::save(state.memory_path(&request.name), &document, false).map_err(server_error)?;
+    state
+        .memories
+        .write()
+        .await
+        .insert(request.name, document.clone());
+    Ok(Json(document))
+}
+
+async fn get_memory(
+    State(state): State<AppState>,
+    AxumPath(name): AxumPath<String>,
+) -> Result<Json<RbmemDocument>, (StatusCode, Json<ErrorResponse>)> {
+    Ok(Json(load_memory(&state, &name).await?))
+}
+
+async fn put_memory(
+    State(state): State<AppState>,
+    AxumPath(name): AxumPath<String>,
+    Json(document): Json<RbmemDocument>,
+) -> Result<Json<RbmemDocument>, (StatusCode, Json<ErrorResponse>)> {
+    crate::save(state.memory_path(&name), &document, false).map_err(server_error)?;
+    state.memories.write().await.insert(name, document.clone());
+    Ok(Json(document))
+}
+
+async fn delete_memory(
+    State(state): State<AppState>,
+    AxumPath(name): AxumPath<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    state.memories.write().await.remove(&name);
+    let path = state.memory_path(&name);
+    if path.exists() {
+        std::fs::remove_file(path)
+            .map_err(RbmemError::from)
+            .map_err(server_error)?;
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn get_section(
+    State(state): State<AppState>,
+    AxumPath((name, path)): AxumPath<(String, String)>,
+) -> Result<Json<Value>, (StatusCode, Json<ErrorResponse>)> {
+    let document = load_memory(&state, &name).await?;
+    let section = document
+        .sections
+        .iter()
+        .find(|section| section.path == path)
+        .ok_or_else(|| not_found(format!("section '{path}' not found")))?;
+    Ok(Json(json!(section)))
+}
+
+async fn put_section(
+    State(state): State<AppState>,
+    AxumPath((name, path)): AxumPath<(String, String)>,
+    Json(request): Json<SectionUpsertRequest>,
+) -> Result<Json<RbmemDocument>, (StatusCode, Json<ErrorResponse>)> {
+    let now = Utc::now();
+    let mut document = load_memory(&state, &name).await?;
+    let section_type = request
+        .section_type
+        .parse::<SectionType>()
+        .map_err(server_error)?;
+    document.upsert_section(&path, section_type, request.content, now);
+    crate::save(state.memory_path(&name), &document, false).map_err(server_error)?;
+    state.memories.write().await.insert(name, document.clone());
+    Ok(Json(document))
+}
+
+async fn delete_section(
+    State(state): State<AppState>,
+    AxumPath((name, path)): AxumPath<(String, String)>,
+) -> Result<Json<RbmemDocument>, (StatusCode, Json<ErrorResponse>)> {
+    let mut document = load_memory(&state, &name).await?;
+    document.sections.retain(|section| section.path != path);
+    crate::save(state.memory_path(&name), &document, false).map_err(server_error)?;
+    state.memories.write().await.insert(name, document.clone());
+    Ok(Json(document))
+}
+
+async fn query_memory(
+    State(state): State<AppState>,
+    AxumPath(name): AxumPath<String>,
+    Json(request): Json<QueryRequest>,
+) -> Result<Json<Value>, (StatusCode, Json<ErrorResponse>)> {
+    let document = load_memory(&state, &name).await?;
+    let context = query_document(
+        &document,
+        &request.text,
+        request.resolve,
+        request.graph_depth,
+    );
+    Ok(Json(context_json(
+        ContextOutputRequest {
+            operation: "query".into(),
+            file: state.memory_path(&name).display().to_string(),
+            selector_name: "text".into(),
+            selector_value: request.text,
+            resolve: request.resolve,
+            compact: request.compact,
+            minified: request.minified,
+            graph_depth: request.graph_depth,
+            format: OutputFormat::Json,
+        },
+        &document,
+        &context,
+    )))
+}
+
+async fn context_memory(
+    State(state): State<AppState>,
+    AxumPath(name): AxumPath<String>,
+    Json(request): Json<QueryRequest>,
+) -> Result<Json<Value>, (StatusCode, Json<ErrorResponse>)> {
+    let document = load_memory(&state, &name).await?;
+    let context = query_document(
+        &document,
+        &request.text,
+        request.resolve,
+        request.graph_depth,
+    );
+    Ok(Json(json!({
+        "context": render_context_document(&context, request.resolve, request.compact, request.minified)
+    })))
+}
+
+async fn diff_memory(
+    State(state): State<AppState>,
+    AxumPath(name): AxumPath<String>,
+    Json(request): Json<DiffRequest>,
+) -> Result<Json<Value>, (StatusCode, Json<ErrorResponse>)> {
+    let document = load_memory(&state, &name).await?;
+    let other = load_memory(&state, &request.other).await?;
+    Ok(Json(
+        json!({ "diff": crate::diff_with_format(&document, &other, request.format).map_err(server_error)? }),
+    ))
+}
+
+async fn merge_memory(
+    State(state): State<AppState>,
+    AxumPath(name): AxumPath<String>,
+    Json(request): Json<MergeRequest>,
+) -> Result<Json<RbmemDocument>, (StatusCode, Json<ErrorResponse>)> {
+    let local = load_memory(&state, &name).await?;
+    let base = load_memory(&state, &request.base).await?;
+    let remote = load_memory(&state, &request.remote).await?;
+    Ok(Json(merge_documents(
+        &base,
+        &local,
+        &remote,
+        request.strategy,
+        Utc::now(),
+    )))
+}
+
+async fn export_memory(
+    State(state): State<AppState>,
+    AxumPath(name): AxumPath<String>,
+    Json(request): Json<ExportRequest>,
+) -> Result<Json<Value>, (StatusCode, Json<ErrorResponse>)> {
+    let document = load_memory(&state, &name).await?;
+    Ok(Json(
+        json!({ "export": export_graph(&document, request.format).map_err(server_error)? }),
+    ))
+}
+
+async fn load_memory(
+    state: &AppState,
+    name: &str,
+) -> Result<RbmemDocument, (StatusCode, Json<ErrorResponse>)> {
+    if let Some(document) = state.memories.read().await.get(name).cloned() {
+        return Ok(document);
+    }
+    let document =
+        crate::load(state.memory_path(name), TimestampPolicy::Preserve).map_err(server_error)?;
+    state
+        .memories
+        .write()
+        .await
+        .insert(name.to_string(), document.clone());
+    Ok(document)
+}
+
+fn default_text_type() -> String {
+    "text".to_string()
+}
+
+fn default_diff_format() -> DiffFormat {
+    DiffFormat::Text
+}
+
+fn default_merge_strategy() -> MergeStrategy {
+    MergeStrategy::Manual
+}
+
+fn server_error(error: RbmemError) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse {
+            error: error.to_string(),
+        }),
+    )
+}
+
+fn not_found(message: String) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse { error: message }),
+    )
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,10 @@
+pub const RBMEM_FORMAT_VERSION: &str = "1.4.0";
+pub const RBMEM_LEGACY_FORMAT_VERSION: &str = "1.3";
+pub const RBMEM_FORMAT_LABEL: &str = "RBMEM v1.4.0";
+
+pub fn is_supported_format_version(version: &str) -> bool {
+    matches!(
+        version.trim(),
+        RBMEM_FORMAT_VERSION | "1.4" | RBMEM_LEGACY_FORMAT_VERSION | "1.3.0"
+    )
+}

--- a/tests/parser_regression.rs
+++ b/tests/parser_regression.rs
@@ -1,0 +1,86 @@
+use chrono::{TimeZone, Utc};
+use rbmem::parser::parse_document;
+use rbmem::{SectionType, TimestampPolicy};
+
+fn fixed_time() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 5, 12, 9, 0, 0).unwrap()
+}
+
+#[test]
+fn parser_survives_common_llm_output_variants() {
+    let now = fixed_time();
+    let cases = [
+        "meta:\n  version: 1.3\n[SECTION: a]\ntype: text\ncontent: |\n  hello\n[END SECTION]\n",
+        "meta:\n  version: 1.2\n[SECTION: a]\ntype: text\ncontent: hi\n[END SECTION]\n",
+        "meta:\n[SECTION: missing.type]\ncontent: |\n  defaults\n[END SECTION]\n",
+        "meta:\n  version: 1.3\ntext[SECTION: prefixed]\ntype: list\ncontent: |\n  - one\n[END SECTION]\n",
+        "meta:\n  version: 1.3\n=== SECTION: human\ncontent: Human note.\n=== END SECTION\n",
+        "meta:\n  version: 1.3\n[SECTION: json]\ntype: json\ncontent: |\n  {\"a\":1}\n[END SECTION]\n",
+        "meta:\n  version: 1.3\n[SECTION: timeline]\ntype: timeline\ncontent: |\n  2026: event\n[END SECTION]\n",
+        "meta:\n  version: 1.3\n[SECTION: template]\ntype: template\ncontent: |\n  Hello {{name}}\n[END SECTION]\n",
+        "meta:\n  version: 1.3\n[SECTION: memory]\ntype: hermes:memory\ncontent: |\n  - fact\n[END SECTION]\n",
+        "meta:\n  version: 1.3\n[SECTION: encrypted]\ntype: encrypted\nnonce: \"aaaaaaaaaaaaaaaa\"\nciphertext: \"bbbb\"\nencrypted_at: \"2026-05-12T09:00:00Z\"\n[END SECTION]\n",
+        "meta:\n  version: 1.3\n[SECTION: conflict]\ntype: conflict\ncontent: |\n  conflict_at: now\n[END SECTION]\n",
+        "meta:\n  version: 1.3\n[SECTION: source]\ntype: text\nsource:\n  kind: \"markdown\"\n  path: \"notes/a.md\"\n  actor: \"sync\"\n  hash: \"sha256:abc\"\ncontent: |\n  sourced\n[END SECTION]\n",
+        "meta:\n  version: 1.3\n[SECTION: graph]\ntype: text\ngraph:\n  node_type: \"Rule\"\n  relations:\n    - to: \"other\"\n      type: \"depends_on\"\ncontent: |\n  linked\n[END SECTION]\n",
+        "meta:\n  version: 1.3\n  compact_mode: minified\n[SECTION: compact]\ncontent: compact\n[END SECTION]\n",
+        "meta:\n  version: 1.3\n  default_expiry_days: 7\n[SECTION: expiry]\ncontent: expires\n[END SECTION]\n",
+        "meta:\n  version: 1.3\n[SECTION: markdown]\ntype: text\ncontent: |\n  # This is content\n  [not a section]\n[END SECTION]\n",
+        "meta:\n  version: 1.3\r\n[SECTION: crlf]\r\ntype: text\r\ncontent: |\r\n  ok\r\n[END SECTION]\r\n",
+        "meta:\n  version: 1.3\n\n\n[SECTION: blanks]\n\ncontent: |\n\n  ok\n\n[END SECTION]\n",
+        "# preface\nmeta:\n  version: 1.3\n[SECTION: preface]\ncontent: ok\n[END SECTION]\n",
+        "meta:\n  version: 1.3\n[SECTION: duplicate]\ncontent: one\n[END SECTION]\n[SECTION: duplicate]\ncontent: two\n[END SECTION]\n",
+    ];
+
+    for (index, input) in cases.iter().enumerate() {
+        let parsed = parse_document(input, TimestampPolicy::Protect { now })
+            .unwrap_or_else(|error| panic!("case {index} failed: {error}"));
+        assert!(
+            !parsed.document.sections.is_empty(),
+            "case {index} produced no sections"
+        );
+    }
+}
+
+#[test]
+fn parser_tracks_source_version_and_source_hash() {
+    let parsed = parse_document(
+        r#"meta:
+  version: 1.2
+[SECTION: synced]
+type: text
+source:
+  kind: "markdown"
+  path: "notes/a.md"
+  actor: "sync"
+  hash: "sha256:abc"
+content: |
+  hello
+[END SECTION]
+"#,
+        TimestampPolicy::Preserve,
+    )
+    .unwrap();
+
+    assert_eq!(parsed.document.meta.version, "1.4.0");
+    assert_eq!(parsed.document.meta.source_version.as_deref(), Some("1.2"));
+    assert_eq!(
+        parsed.document.sections[0]
+            .source
+            .as_ref()
+            .and_then(|source| source.hash.as_deref()),
+        Some("sha256:abc")
+    );
+}
+
+#[test]
+fn parser_accepts_new_section_types() {
+    assert_eq!(
+        "encrypted".parse::<SectionType>().unwrap(),
+        SectionType::Encrypted
+    );
+    assert_eq!(
+        "conflict".parse::<SectionType>().unwrap(),
+        SectionType::Conflict
+    );
+}

--- a/tests/rbmem_api.rs
+++ b/tests/rbmem_api.rs
@@ -1,0 +1,156 @@
+use chrono::{TimeZone, Utc};
+use rbmem::{
+    context, create, delete_section, query, read, update, ContextOptions, CreateOptions,
+    OutputFormat, ReadOptions, SectionType, TimestampPolicy, UpdateOptions,
+};
+use std::fs;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+fn temp_test_dir(name: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("rbmem-api-{name}-{suffix}"))
+}
+
+#[test]
+fn public_api_create_update_read_query_and_context() {
+    let root = temp_test_dir("milestone-1");
+    fs::create_dir_all(&root).unwrap();
+    let file = root.join("memory.rbmem");
+    let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
+
+    let created = create(
+        &file,
+        CreateOptions {
+            created_by: "api-test".to_string(),
+            purpose: "library smoke test".to_string(),
+            default_expiry_days: None,
+            human: false,
+            now,
+        },
+    )
+    .unwrap();
+    assert_eq!(created.meta.created_by, "api-test");
+
+    let updated = update(
+        &file,
+        UpdateOptions {
+            section: "agents.reader".to_string(),
+            section_type: SectionType::Text,
+            content: "Reads memory carefully for github code review.".to_string(),
+            human: false,
+            dry_run: false,
+            now,
+        },
+    )
+    .unwrap();
+    assert_eq!(updated.sections.len(), 1);
+
+    let full = read(
+        &file,
+        ReadOptions {
+            resolve: false,
+            compact: false,
+            minified: false,
+            hide_empty_temporal: false,
+            decrypt: false,
+            key: None,
+            policy: TimestampPolicy::Preserve,
+        },
+    )
+    .unwrap();
+    assert!(full.contains("[SECTION: agents.reader]"));
+
+    let query_output = query(
+        &file,
+        "github code review",
+        ContextOptions {
+            resolve: true,
+            compact: false,
+            minified: true,
+            graph_depth: 0,
+            decrypt: false,
+            key: None,
+            format: OutputFormat::Text,
+            policy: TimestampPolicy::Preserve,
+        },
+    )
+    .unwrap();
+    assert!(query_output.contains("[agents.reader]"));
+
+    let context_output = context(
+        &file,
+        "review this PR",
+        ContextOptions {
+            resolve: true,
+            compact: false,
+            minified: true,
+            graph_depth: 0,
+            decrypt: false,
+            key: None,
+            format: OutputFormat::Json,
+            policy: TimestampPolicy::Preserve,
+        },
+    )
+    .unwrap();
+    assert!(context_output.contains("\"schema\": \"rbmem.context.v1\""));
+    assert!(context_output.contains("\"operation\": \"context\""));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn public_api_update_dry_run_and_delete_section() {
+    let root = temp_test_dir("dry-run-delete");
+    fs::create_dir_all(&root).unwrap();
+    let file = root.join("memory.rbmem");
+    let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 15, 0).unwrap();
+
+    create(
+        &file,
+        CreateOptions {
+            created_by: "api-test".to_string(),
+            purpose: "library dry run test".to_string(),
+            default_expiry_days: None,
+            human: false,
+            now,
+        },
+    )
+    .unwrap();
+
+    update(
+        &file,
+        UpdateOptions {
+            section: "scratch".to_string(),
+            section_type: SectionType::Text,
+            content: "not persisted".to_string(),
+            human: false,
+            dry_run: true,
+            now,
+        },
+    )
+    .unwrap();
+    assert!(!fs::read_to_string(&file).unwrap().contains("not persisted"));
+
+    update(
+        &file,
+        UpdateOptions {
+            section: "scratch".to_string(),
+            section_type: SectionType::Text,
+            content: "persisted".to_string(),
+            human: false,
+            dry_run: false,
+            now,
+        },
+    )
+    .unwrap();
+    delete_section(&file, "scratch", false, now).unwrap();
+    assert!(!fs::read_to_string(&file)
+        .unwrap()
+        .contains("[SECTION: scratch]"));
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/tests/rbmem_diff_merge.rs
+++ b/tests/rbmem_diff_merge.rs
@@ -1,0 +1,69 @@
+use chrono::{TimeZone, Utc};
+use rbmem::{
+    diff_with_format, merge_documents, DiffFormat, MergeStrategy, RbmemDocument, SectionType,
+};
+
+fn fixed_time() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 5, 7, 13, 0, 0).unwrap()
+}
+
+#[test]
+fn typed_diff_renders_json_and_text() {
+    let now = fixed_time();
+    let mut before = RbmemDocument::new(now, "me");
+    before.upsert_section("rules", SectionType::Text, "old".to_string(), now);
+
+    let mut after = before.clone();
+    after.upsert_section("rules", SectionType::Text, "new".to_string(), now);
+    after.upsert_section("memory", SectionType::Text, "added".to_string(), now);
+
+    let text = diff_with_format(&before, &after, DiffFormat::Text).unwrap();
+    assert!(text.contains("added: memory"));
+    assert!(text.contains("changed content: rules"));
+
+    let json = diff_with_format(&before, &after, DiffFormat::Json).unwrap();
+    assert!(json.contains("\"schema\": \"rbmem.diff.v1\""));
+    assert!(json.contains("\"path\": \"memory\""));
+}
+
+#[test]
+fn three_way_merge_auto_resolves_theirs_when_local_matches_base() {
+    let now = fixed_time();
+    let mut base = RbmemDocument::new(now, "me");
+    base.upsert_section("rules", SectionType::Text, "base".to_string(), now);
+    let local = base.clone();
+    let mut remote = base.clone();
+    remote.upsert_section("rules", SectionType::Text, "remote".to_string(), now);
+
+    let merged = merge_documents(&base, &local, &remote, MergeStrategy::Manual, now);
+    let section = merged
+        .sections
+        .iter()
+        .find(|section| section.path == "rules")
+        .unwrap();
+
+    assert_eq!(section.content, "remote");
+    assert_eq!(section.section_type, SectionType::Text);
+}
+
+#[test]
+fn three_way_merge_manual_emits_conflict_section_for_true_conflict() {
+    let now = fixed_time();
+    let mut base = RbmemDocument::new(now, "me");
+    base.upsert_section("rules", SectionType::Text, "base".to_string(), now);
+    let mut local = base.clone();
+    local.upsert_section("rules", SectionType::Text, "local".to_string(), now);
+    let mut remote = base.clone();
+    remote.upsert_section("rules", SectionType::Text, "remote".to_string(), now);
+
+    let merged = merge_documents(&base, &local, &remote, MergeStrategy::Manual, now);
+    let section = merged
+        .sections
+        .iter()
+        .find(|section| section.path == "rules")
+        .unwrap();
+
+    assert_eq!(section.section_type, SectionType::Conflict);
+    assert!(section.content.contains("local_version:"));
+    assert!(section.content.contains("remote_version:"));
+}

--- a/tests/rbmem_encryption.rs
+++ b/tests/rbmem_encryption.rs
@@ -1,0 +1,173 @@
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use chrono::{TimeZone, Utc};
+use rbmem::{
+    create, encrypt_section, query, read, update, ContextOptions, CreateOptions, EncryptionKey,
+    OutputFormat, ReadOptions, SectionType, TimestampPolicy, UpdateOptions,
+};
+use std::fs;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+fn temp_test_dir(name: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("rbmem-encryption-{name}-{suffix}"))
+}
+
+fn test_key() -> EncryptionKey {
+    EncryptionKey::from_bytes([7u8; 32])
+}
+
+#[test]
+fn encrypted_sections_are_skipped_unless_decrypt_is_enabled() {
+    let root = temp_test_dir("read");
+    fs::create_dir_all(&root).unwrap();
+    let file = root.join("memory.rbmem");
+    let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 30, 0).unwrap();
+
+    create(
+        &file,
+        CreateOptions {
+            created_by: "api-test".to_string(),
+            purpose: "encryption smoke test".to_string(),
+            default_expiry_days: None,
+            human: false,
+            now,
+        },
+    )
+    .unwrap();
+    update(
+        &file,
+        UpdateOptions {
+            section: "secrets.api".to_string(),
+            section_type: SectionType::Text,
+            content: "token=super-secret".to_string(),
+            human: false,
+            dry_run: false,
+            now,
+        },
+    )
+    .unwrap();
+
+    let encrypted = encrypt_section(&file, "secrets.api", &test_key(), now).unwrap();
+    assert_eq!(encrypted.sections[0].section_type, SectionType::Encrypted);
+
+    let raw = fs::read_to_string(&file).unwrap();
+    assert!(raw.contains("type: encrypted"));
+    assert!(raw.contains("nonce:"));
+    assert!(raw.contains("ciphertext:"));
+    assert!(!raw.contains("super-secret"));
+
+    let hidden = read(
+        &file,
+        ReadOptions {
+            resolve: false,
+            compact: false,
+            minified: false,
+            hide_empty_temporal: false,
+            decrypt: false,
+            key: None,
+            policy: TimestampPolicy::Preserve,
+        },
+    )
+    .unwrap();
+    assert!(!hidden.contains("secrets.api"));
+    assert!(!hidden.contains("super-secret"));
+
+    let decrypted = read(
+        &file,
+        ReadOptions {
+            resolve: false,
+            compact: false,
+            minified: false,
+            hide_empty_temporal: false,
+            decrypt: true,
+            key: Some(test_key()),
+            policy: TimestampPolicy::Preserve,
+        },
+    )
+    .unwrap();
+    assert!(decrypted.contains("[SECTION: secrets.api]"));
+    assert!(decrypted.contains("super-secret"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn encrypted_sections_are_queryable_only_with_decryption() {
+    let root = temp_test_dir("query");
+    fs::create_dir_all(&root).unwrap();
+    let file = root.join("memory.rbmem");
+    let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 45, 0).unwrap();
+
+    create(
+        &file,
+        CreateOptions {
+            created_by: "api-test".to_string(),
+            purpose: "encryption query test".to_string(),
+            default_expiry_days: None,
+            human: false,
+            now,
+        },
+    )
+    .unwrap();
+    update(
+        &file,
+        UpdateOptions {
+            section: "secrets.review".to_string(),
+            section_type: SectionType::Text,
+            content: "github review secret phrase".to_string(),
+            human: false,
+            dry_run: false,
+            now,
+        },
+    )
+    .unwrap();
+    encrypt_section(&file, "secrets.review", &test_key(), now).unwrap();
+
+    let hidden = query(
+        &file,
+        "secret phrase",
+        ContextOptions {
+            resolve: false,
+            compact: false,
+            minified: true,
+            graph_depth: 0,
+            decrypt: false,
+            key: None,
+            format: OutputFormat::Text,
+            policy: TimestampPolicy::Preserve,
+        },
+    )
+    .unwrap();
+    assert!(!hidden.contains("secret phrase"));
+
+    let decrypted = query(
+        &file,
+        "secret phrase",
+        ContextOptions {
+            resolve: false,
+            compact: false,
+            minified: true,
+            graph_depth: 0,
+            decrypt: true,
+            key: Some(test_key()),
+            format: OutputFormat::Text,
+            policy: TimestampPolicy::Preserve,
+        },
+    )
+    .unwrap();
+    assert!(decrypted.contains("secret phrase"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn encryption_key_decodes_from_environment_style_base64() {
+    let encoded = STANDARD.encode([9u8; 32]);
+    let key = EncryptionKey::from_env_value(&encoded).unwrap();
+
+    assert_eq!(key.as_bytes(), &[9u8; 32]);
+}

--- a/tests/rbmem_export.rs
+++ b/tests/rbmem_export.rs
@@ -1,0 +1,36 @@
+use chrono::{TimeZone, Utc};
+use rbmem::{export_graph, ExportFormat, RbmemDocument, SectionType};
+
+fn fixed_time() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 5, 7, 14, 0, 0).unwrap()
+}
+
+#[test]
+fn exports_graph_visualization_formats() {
+    let now = fixed_time();
+    let mut document = RbmemDocument::new(now, "me");
+    document.upsert_section(
+        "agents.reader",
+        SectionType::Text,
+        "Reader.".to_string(),
+        now,
+    );
+    document.upsert_section(
+        "agents.writer",
+        SectionType::Text,
+        "Writer.".to_string(),
+        now,
+    );
+
+    let mermaid = export_graph(&document, ExportFormat::Mermaid).unwrap();
+    assert!(mermaid.contains("graph TD"));
+    assert!(mermaid.contains("agents.reader"));
+
+    let cytoscape = export_graph(&document, ExportFormat::Cytoscape).unwrap();
+    assert!(cytoscape.contains("\"nodes\""));
+    assert!(cytoscape.contains("\"edges\""));
+
+    let gexf = export_graph(&document, ExportFormat::Gexf).unwrap();
+    assert!(gexf.contains("<gexf"));
+    assert!(gexf.contains("<edges>"));
+}

--- a/tests/rbmem_index.rs
+++ b/tests/rbmem_index.rs
@@ -1,0 +1,50 @@
+use chrono::{TimeZone, Utc};
+use rbmem::{RbmemDocument, SectionIndex, SectionType};
+
+fn fixed_time() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 5, 7, 13, 30, 0).unwrap()
+}
+
+#[test]
+fn index_finds_keywords_prefixes_and_related_sections() {
+    let now = fixed_time();
+    let mut document = RbmemDocument::new(now, "me");
+    document.upsert_section(
+        "agents.reader",
+        SectionType::Text,
+        "Performs careful github review.".to_string(),
+        now,
+    );
+    document.upsert_section(
+        "agents.writer",
+        SectionType::Text,
+        "Writes summaries.".to_string(),
+        now,
+    );
+    document.upsert_section(
+        "memory.testing",
+        SectionType::Text,
+        "Run tests.".to_string(),
+        now,
+    );
+    document.sections[0].graph = Some(rbmem::document::GraphInfo {
+        node_type: None,
+        relations: vec![rbmem::GraphRelation {
+            to: "memory.testing".to_string(),
+            relation_type: "depends_on".to_string(),
+            valid_from: Some(now),
+            valid_until: None,
+            inferred: false,
+            confidence: None,
+        }],
+    });
+
+    let index = SectionIndex::build(&document);
+
+    assert_eq!(index.keyword("github"), vec!["agents.reader"]);
+    assert_eq!(
+        index.prefix("agents.*"),
+        vec!["agents.reader", "agents.writer"]
+    );
+    assert_eq!(index.related("agents.reader", 1), vec!["memory.testing"]);
+}

--- a/tests/rbmem_server.rs
+++ b/tests/rbmem_server.rs
@@ -1,0 +1,24 @@
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use rbmem::server::{app, AppState};
+use serde_json::Value;
+use std::path::PathBuf;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn server_health_endpoint_reports_ok() {
+    let response = app(AppState::new(PathBuf::from(".")))
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(value["status"], "ok");
+}


### PR DESCRIPTION
## Summary

Describe the change and why it is needed.

## Compatibility

- [ ] Existing `.aif` files continue to parse.
- [ ] CLI output changes are intentional and documented.
- [ ] Protected timestamp behavior is preserved.

## Tests

Commands run:

```powershell
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-features
cargo build --release --all-features
```

## Notes

Add any follow-up work or review focus areas.
