### PR TITLE
[codex] add SAT planning to rbmem

### DIFF
--- a/HERMES.md
+++ b/HERMES.md
@@ -22,6 +22,10 @@ rbmem sync notes RBMEM-memory --watch --infer-relations
 
 - Load memory before planning:
   `rbmem hermes load project.rbmem --resolve --compact`
+- Use SAT planning for constrained task plans:
+  `rbmem plan "<goal>" --file project.rbmem --format json`
+- Add `--pack <name>` when the task should be planned against a stored context pack.
+- Use `rbmem plan --from-memory --file project.rbmem --format json` when the active goal is already stored in `goals` or `tasks`.
 - Treat `sections[].path` as the stable memory address.
 - Prefer `hermes:memory` for append-only facts, preferences, and observations.
 - `hermes:memory` sections are append-only; use `mode: "auto"` or `mode: "append"`.
@@ -218,7 +222,7 @@ Use CLI commands for human-operated workflows and one-off tasks. Use server mode
 
 ### Harness Decision Rules
 
-- For planning: `query` or `context` first, full `hermes load` only if the selected context is insufficient.
+- For planning: use `rbmem plan` when rules, constraints, prerequisites, or conflicts matter; use `query` or `context` for lightweight retrieval.
 - For sensitive data: encrypt the section, retrieve with `--decrypt` only for the exact task, and never persist decrypted material elsewhere.
 - For updates: write with `hermes save`, then run `diff`, `review`, and `doctor`.
 - For conflicting memory: run `merge --strategy manual` and treat conflict sections as requiring human or explicit agent resolution.
@@ -231,6 +235,14 @@ Use the smallest useful context by default:
 
 ```powershell
 rbmem context project.rbmem --task "<current task>" --resolve --minified --graph-depth 1 --format json
+```
+
+When the task needs a concrete feasible plan, ask the SAT planner to write the plan back into RBMEM:
+
+```powershell
+rbmem plan "<current goal>" --file project.rbmem --solver auto --format json
+rbmem plan --from-memory --file project.rbmem --cube-and-conquer --format json
+rbmem plan "<current goal>" --file project.rbmem --pack code_review --format json
 ```
 
 Fall back to the full Hermes JSON view when the agent needs complete memory state:

--- a/HERMES.md
+++ b/HERMES.md
@@ -23,9 +23,9 @@ rbmem sync notes RBMEM-memory --watch --infer-relations
 - Load memory before planning:
   `rbmem hermes load project.rbmem --resolve --compact`
 - Use SAT planning for constrained task plans:
-  `rbmem plan "<goal>" --file project.rbmem --format json`
+  `rbmem hermes plan project.rbmem --goal "<goal>" --format json`
 - Add `--pack <name>` when the task should be planned against a stored context pack.
-- Use `rbmem plan --from-memory --file project.rbmem --format json` when the active goal is already stored in `goals` or `tasks`.
+- Use `rbmem hermes plan project.rbmem --from-memory --format json` when the active goal is already stored in `goals` or `tasks`.
 - Treat `sections[].path` as the stable memory address.
 - Prefer `hermes:memory` for append-only facts, preferences, and observations.
 - `hermes:memory` sections are append-only; use `mode: "auto"` or `mode: "append"`.
@@ -240,9 +240,9 @@ rbmem context project.rbmem --task "<current task>" --resolve --minified --graph
 When the task needs a concrete feasible plan, ask the SAT planner to write the plan back into RBMEM:
 
 ```powershell
-rbmem plan "<current goal>" --file project.rbmem --solver auto --format json
-rbmem plan --from-memory --file project.rbmem --cube-and-conquer --format json
-rbmem plan "<current goal>" --file project.rbmem --pack code_review --format json
+rbmem hermes plan project.rbmem --goal "<current goal>" --solver auto --format json
+rbmem hermes plan project.rbmem --from-memory --cube-and-conquer --format json
+rbmem hermes plan project.rbmem --goal "<current goal>" --pack code_review --format json
 ```
 
 Fall back to the full Hermes JSON view when the agent needs complete memory state:

--- a/README.md
+++ b/README.md
@@ -246,6 +246,13 @@ Load Hermes-optimized JSON:
 .\target\release\rbmem.exe hermes load my-agent-memory.rbmem --resolve --minified
 ```
 
+Plan from Hermes memory with the native SAT planner:
+
+```powershell
+.\target\release\rbmem.exe hermes plan my-agent-memory.rbmem --goal "deploy agent release" --format json
+.\target\release\rbmem.exe hermes plan my-agent-memory.rbmem --from-memory --pack release_ops --format json
+```
+
 Save agent memory safely:
 
 ```powershell
@@ -367,6 +374,7 @@ See [HERMES.md](HERMES.md) for agent instructions and the save payload shape. Se
 | `timeline <file.rbmem>` | Show temporal entries. |
 | `validate <file.rbmem>` | Validate parser compatibility. |
 | `hermes load <file.rbmem>` | Output Hermes-friendly JSON. |
+| `hermes plan <file.rbmem> --goal <goal>` | Run SAT planning as a Hermes-native memory operation and store the plan in RBMEM. |
 | `hermes save <file.rbmem> --json <payload>` | Apply Hermes-style memory updates. |
 | `hermes save <file.rbmem> --json-file payload.json` | Apply Hermes updates from a file. |
 | `hermes doctor <file.rbmem>` | Check RBMEM memory health and verify Hermes JSON/context loading; supports `--format json`. |

--- a/README.md
+++ b/README.md
@@ -107,6 +107,56 @@ Ask RBMEM for task-specific context:
 ./target/release/rbmem context memory.rbmem --task "review this PR" --resolve --minified
 ```
 
+## SAT Planning
+
+Rust-Brain now includes advanced SAT planning as a first-class RBMEM feature. `rbmem plan` loads goals, tasks, rules, constraints, preferences, graph context, and context sections from `.rbmem` files, encodes the planning problem as CNF, solves it with Kissat/CaDiCaL when available, falls back to a native Rust DPLL solver, and stores the resulting plan back into memory with timestamps and graph relations.
+
+Plan from an explicit goal:
+
+```powershell
+.\target\release\rbmem.exe plan "deploy agent release" --file examples\sat-planning.rbmem
+```
+
+Derive the goal from memory:
+
+```powershell
+.\target\release\rbmem.exe plan --from-memory --file examples\sat-planning.rbmem
+```
+
+Use solver/proof options:
+
+```powershell
+.\target\release\rbmem.exe plan "deploy agent release" --file examples\sat-planning.rbmem --solver kissat --proof --verify-proof
+.\target\release\rbmem.exe plan "deploy agent release" --file examples\sat-planning.rbmem --cube-and-conquer --format json
+```
+
+Plan with a stored context pack:
+
+```powershell
+.\target\release\rbmem.exe plan "deploy agent release" --file examples\sat-planning.rbmem --pack release_ops
+```
+
+The planner writes sections under `plans.<goal>.<timestamp>.*`:
+
+```text
+plans.deploy-agent-release-20260518200000.goal
+plans.deploy-agent-release-20260518200000.steps
+plans.deploy-agent-release-20260518200000.sat
+plans.deploy-agent-release-20260518200000.proof
+timeline
+```
+
+Rules can be plain RBMEM list items:
+
+```text
+- deploy agent release requires run focused regression tests
+- publish release notes requires deploy agent release
+- gather requirements conflicts with deploy agent release
+- avoid deploying without validation
+```
+
+DRAT support is proof-aware: external proof-producing solvers and `drat-trim` are used when installed; the native solver records the DIMACS/model for SAT plans and verifies simple empty-clause UNSAT proofs internally.
+
 ## RBMEM At A Glance
 
 An RBMEM file is plain text:
@@ -300,6 +350,8 @@ See [HERMES.md](HERMES.md) for agent instructions and the save payload shape. Se
 | `infer <file.rbmem>` | Infer graph relations from prose. |
 | `query <file.rbmem> <text>` | Return matching task-specific context; use `--format json` or `--decrypt` when needed. |
 | `context <file.rbmem> --task <text>` | Alias for task-oriented context assembly; use `--format json` or `--decrypt` when needed. |
+| `plan "<goal>" [--file <file.rbmem>] [--pack <name>]` | Build a SAT planning problem from RBMEM memory, solve it, and store the resulting plan back into memory. |
+| `plan --from-memory [--file <file.rbmem>]` | Derive the goal from `goals`/`tasks` sections before planning. |
 | `pack <file.rbmem> <name>` | Render a named context pack from `.rbmempacks`; use `--format json` for tool callers. |
 | `diff <before.rbmem> <after.rbmem> --format text|json|yaml` | Report typed section-level memory changes. |
 | `merge <base.rbmem> <local.rbmem> <remote.rbmem> --strategy manual` | Run a three-way section merge. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,6 +6,7 @@
 | --- | --- |
 | `src/parser.rs` | Forgiving Nom parser for RBMEM v1.3 syntax, including canonical and human-friendly section delimiters. |
 | `src/document.rs` | Core data model, smart merge, timestamp protection, provenance, graph view, compact rendering, relation inference, and validation helpers. |
+| `src/planner/` | SAT planning engine that extracts actions/rules from RBMEM, emits CNF, solves with Kissat/CaDiCaL or the internal DPLL fallback, handles proof metadata, and writes plans back into the memory graph. |
 | `src/main.rs` | CLI command wiring, Markdown conversion, sync workflow, context query/pack assembly, review/diff commands, Hermes integration, and file I/O. |
 
 ## Data Flow
@@ -21,6 +22,7 @@
    - JSON for Hermes and automation.
    - DOT or JSON graph output.
    - Task-specific context selected by query text, named packs, parent paths, and graph neighbors.
+   - SAT plans selected from goals, tasks, rules, constraints, preferences, and graph context.
 5. Updates write the full durable RBMEM document back to disk.
 
 ## Context Assembly
@@ -43,6 +45,25 @@ RBMEM graph output combines:
 Inference is configurable with `--inference-strategy off|explicit|balanced|aggressive`. `balanced` preserves the default heuristic, `explicit` accepts only direct relation phrases, and `aggressive` lowers the effective confidence threshold for recall-heavy agent indexing. Markdown sync can set the same behavior in `.rbmemsync` with `inference_strategy: explicit`.
 
 Graph JSON marks each edge source so agents can distinguish trusted manual edges from inferred ones.
+
+## SAT Planning
+
+`rbmem plan` is a native memory operation, not a sidecar planner. It discovers `.rbmem` files, chooses a primary memory file, extracts candidate actions from `goals`, `tasks`, `actions`, `steps`, and `plans`, then turns simple rule prose into SAT clauses:
+
+- `A requires B` or `A depends on B` becomes `not A or B`.
+- `A conflicts with B` becomes `not A or not B`.
+- `must/include/always <phrase>` becomes a required action clause.
+- `avoid/never/do not <phrase>` becomes a negative action clause.
+
+The solver path is:
+
+1. `--solver auto` tries `kissat`, then `cadical`, then the native DPLL fallback.
+2. `--solver internal` uses only the Rust implementation.
+3. `--cube-and-conquer` splits the first few variables into cubes and solves each subproblem.
+
+Plans are written under `plans.<goal>.<timestamp>.*` with `goal`, `steps`, `sat`, and `proof` sections. The planner stamps sections with `source.kind = "planner"` and adds graph relations such as `has_steps`, `encoded_as`, `uses_context`, `has_proof`, and `verifies`.
+
+DRAT support is integrated at the artifact layer. External proof-producing solvers and `drat-trim` can be used when installed; the internal solver records SAT DIMACS/model metadata and verifies simple empty-clause UNSAT proofs.
 
 ## Timestamp Protection
 

--- a/examples/.rbmempacks
+++ b/examples/.rbmempacks
@@ -1,0 +1,9 @@
+[pack: release_ops]
+include:
+  - goals
+  - tasks
+  - rules.release
+  - preferences.release
+query: "deploy release"
+graph_depth: 1
+mode: minified

--- a/examples/sat-planning.rbmem
+++ b/examples/sat-planning.rbmem
@@ -1,0 +1,57 @@
+rbmem# RBMEM v1.4.0 - Rust-Brain Memory Format
+
+meta:
+  version: 1.4.0
+  purpose: "sat-planning-demo"
+  generated_at: "2026-05-18T20:00:00Z"
+  last_updated: "2026-05-18T20:00:00Z"
+  valid_until: null
+  created_by: "rbmem"
+  default_expiry_days: null
+  compact_mode: minified
+
+[SECTION: goals]
+type: list
+temporal:
+  created_at: "2026-05-18T20:00:00Z"
+  updated_at: "2026-05-18T20:00:00Z"
+  expires_at: null
+content: |
+  - deploy the agent release
+[END SECTION]
+
+[SECTION: tasks]
+type: list
+temporal:
+  created_at: "2026-05-18T20:00:00Z"
+  updated_at: "2026-05-18T20:00:00Z"
+  expires_at: null
+content: |
+  - Gather release requirements
+  - Run focused regression tests
+  - Deploy agent release
+  - Publish release notes
+[END SECTION]
+
+[SECTION: rules.release]
+type: list
+temporal:
+  created_at: "2026-05-18T20:00:00Z"
+  updated_at: "2026-05-18T20:00:00Z"
+  expires_at: null
+content: |
+  - deploy agent release requires run focused regression tests
+  - publish release notes requires deploy agent release
+  - gather release requirements conflicts with deploy agent release
+[END SECTION]
+
+[SECTION: preferences.release]
+type: list
+temporal:
+  created_at: "2026-05-18T20:00:00Z"
+  updated_at: "2026-05-18T20:00:00Z"
+  expires_at: null
+content: |
+  - Prefer plans that preserve tests and release notes.
+  - Avoid deploying without validation.
+[END SECTION]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -58,8 +58,8 @@ use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::BTreeSet;
-use std::hash::Hasher;
 use std::fs;
+use std::hash::Hasher;
 use std::path::Path;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -720,7 +720,6 @@ fn sections_json(document: &RbmemDocument, resolve: bool) -> Vec<Value> {
     }
 }
 
-
 pub fn create_snapshot(path: impl AsRef<Path>, label: &str) -> Result<SnapshotRecord, RbmemError> {
     let path = path.as_ref();
     let raw = fs::read_to_string(path)?;
@@ -809,10 +808,9 @@ pub fn rollback_to_snapshot(path: impl AsRef<Path>, label: &str) -> Result<(), R
         }
     }
 
-    let snapshot_file = snapshot_file.ok_or_else(|| {
-        RbmemError::Parse(format!("snapshot '{}' not found", label))
-    })?;
-    
+    let _snapshot_file = snapshot_file
+        .ok_or_else(|| RbmemError::Parse(format!("snapshot '{}' not found", label)))?;
+
     let content_file = content_file.ok_or_else(|| {
         RbmemError::Parse(format!(
             "snapshot content file not found for label '{}'",
@@ -849,7 +847,6 @@ pub fn rollback_to_snapshot(path: impl AsRef<Path>, label: &str) -> Result<(), R
     Ok(())
 }
 
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HealthScore {
     pub total_sections: usize,
@@ -864,9 +861,11 @@ pub fn health_report(path: impl AsRef<Path>, stale_days: u64) -> Result<HealthSc
     let now = Utc::now();
     let stale_cutoff = now - chrono::Duration::days(stale_days as i64);
 
-    let stale_sections = document.sections.iter().filter(|s| {
-        s.temporal.updated_at < stale_cutoff
-    }).count();
+    let stale_sections = document
+        .sections
+        .iter()
+        .filter(|s| s.temporal.updated_at < stale_cutoff)
+        .count();
 
     let orphaned_edges = count_orphaned_edges(&document);
     let conflicts = count_conflicts(&document);
@@ -875,9 +874,9 @@ pub fn health_report(path: impl AsRef<Path>, stale_days: u64) -> Result<HealthSc
     let score = if total == 0.0 {
         100.0
     } else {
-        let penalty = ((stale_sections as f64 / total) * 30.0
+        let penalty = (stale_sections as f64 / total) * 30.0
             + (orphaned_edges as f64 / total.max(1.0)) * 20.0
-            + (conflicts as f64 / total.max(1.0)) * 25.0);
+            + (conflicts as f64 / total.max(1.0)) * 25.0;
         (100.0 - penalty).clamp(0.0, 100.0)
     };
 
@@ -909,7 +908,7 @@ fn count_orphaned_edges(document: &RbmemDocument) -> usize {
 fn count_conflicts(document: &RbmemDocument) -> usize {
     let mut conflicts = 0;
     for i in 0..document.sections.len() {
-        for j in (i+1)..document.sections.len() {
+        for j in (i + 1)..document.sections.len() {
             let s1 = &document.sections[i];
             let s2 = &document.sections[j];
             if s1.path == s2.path && s1.content != s2.content {
@@ -929,27 +928,35 @@ pub fn add_guard(
     let path = path.as_ref();
     let mut document = load(path, TimestampPolicy::Preserve)?;
 
-    let guard_section = document.sections.iter_mut()
+    let guard_section = document
+        .sections
+        .iter_mut()
         .find(|s| s.section_type == SectionType::Guards)
         .ok_or_else(|| RbmemError::Parse("no guards section found".to_string()))?;
 
-    let mut existing_guards: GuardConstraint = serde_json::from_str(&guard_section.content)
-        .unwrap_or_else(|_| GuardConstraint::default());
+    let mut existing_guards: GuardConstraint =
+        serde_json::from_str(&guard_section.content).unwrap_or_else(|_| GuardConstraint::default());
 
     match guard_type {
         "max-tokens" => {
             existing_guards.max_tokens = Some(
-                value.parse::<u64>().map_err(|e| RbmemError::Parse(e.to_string()))?,
+                value
+                    .parse::<u64>()
+                    .map_err(|e| RbmemError::Parse(e.to_string()))?,
             )
         }
         "max-iterations" => {
             existing_guards.max_iterations = Some(
-                value.parse::<u64>().map_err(|e| RbmemError::Parse(e.to_string()))?,
+                value
+                    .parse::<u64>()
+                    .map_err(|e| RbmemError::Parse(e.to_string()))?,
             )
         }
         "max-retries" => {
             existing_guards.max_retries = Some(
-                value.parse::<u64>().map_err(|e| RbmemError::Parse(e.to_string()))?,
+                value
+                    .parse::<u64>()
+                    .map_err(|e| RbmemError::Parse(e.to_string()))?,
             )
         }
         "output-validation" => existing_guards.output_validation = Some(value.to_string()),
@@ -981,12 +988,14 @@ pub fn remove_guard(
     let path = path.as_ref();
     let mut document = load(path, TimestampPolicy::Preserve)?;
 
-    let guard_section = document.sections.iter_mut()
+    let guard_section = document
+        .sections
+        .iter_mut()
         .find(|s| s.section_type == SectionType::Guards)
         .ok_or_else(|| RbmemError::Parse("no guards section found".to_string()))?;
 
-    let mut updated_guards: GuardConstraint = serde_json::from_str(&guard_section.content)
-        .unwrap_or_else(|_| GuardConstraint::default());
+    let mut updated_guards: GuardConstraint =
+        serde_json::from_str(&guard_section.content).unwrap_or_else(|_| GuardConstraint::default());
 
     match guard_type {
         "max-tokens" => updated_guards.max_tokens = None,
@@ -1046,8 +1055,7 @@ pub fn review_out(
             SectionType::Review,
             format!(
                 "[REVIEW] type={}\n{}\n",
-                flagged.section_type,
-                flagged.content
+                flagged.section_type, flagged.content
             ),
             Utc::now(),
         );
@@ -1103,8 +1111,6 @@ pub fn review_commit(
     Ok(applied)
 }
 
-
-
 pub fn list_guards(path: impl AsRef<Path>) -> Result<GuardConstraint, RbmemError> {
     let document = load(path, TimestampPolicy::Preserve)?;
 
@@ -1114,12 +1120,13 @@ pub fn list_guards(path: impl AsRef<Path>) -> Result<GuardConstraint, RbmemError
         .find(|s| s.section_type == SectionType::Guards)
         .ok_or_else(|| RbmemError::Parse("no guards section found".to_string()))?;
 
-    let guards: GuardConstraint = serde_json::from_str(&guard_section.content)
-        .unwrap_or_else(|_| GuardConstraint::default());
+    let guards: GuardConstraint =
+        serde_json::from_str(&guard_section.content).unwrap_or_else(|_| GuardConstraint::default());
 
     Ok(guards)
 }
 
+#[cfg(test)]
 mod tests {
     use super::*;
     use chrono::TimeZone;
@@ -1183,7 +1190,6 @@ mod tests {
         assert!(diff.contains("changed content: rules"));
     }
 
-
     #[test]
     fn test_create_and_list_snapshot() {
         let content = r#"meta:
@@ -1196,8 +1202,13 @@ type: text
 Daniel, PhD CogNeuro UofT
 [END SECTION]
 "#;
-        let dir = std::env::temp_dir().join(format!("rbmem_test_{}", std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+        let dir = std::env::temp_dir().join(format!(
+            "rbmem_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
         let path = dir.join("memory.rbmem");
         std::fs::create_dir_all(&dir).ok();
         std::fs::write(&path, content).ok();
@@ -1227,8 +1238,13 @@ type: text
 original content here
 [END SECTION]
 "#;
-        let dir = std::env::temp_dir().join(format!("rbmem_test_{}", std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+        let dir = std::env::temp_dir().join(format!(
+            "rbmem_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
         let path = dir.join("memory.rbmem");
         std::fs::create_dir_all(&dir).ok();
         std::fs::write(&path, original).ok();
@@ -1263,14 +1279,23 @@ modified content after rollback
 
     #[test]
     fn test_rollback_fails_on_missing_snapshot() {
-        let dir = std::env::temp_dir().join(format!("rbmem_test_{}", std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+        let dir = std::env::temp_dir().join(format!(
+            "rbmem_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
         let path = dir.join("memory.rbmem");
         std::fs::create_dir_all(&dir).ok();
-        std::fs::write(&path, "memory:
+        std::fs::write(
+            &path,
+            "memory:
   test: text
   content: hello
-").ok();
+",
+        )
+        .ok();
 
         let result = rollback_to_snapshot(&path, "nonexistent");
         assert!(result.is_err());
@@ -1279,5 +1304,4 @@ modified content after rollback
         // Cleanup
         let _ = std::fs::remove_dir_all(dir);
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,18 @@ pub mod document;
 pub mod export;
 pub mod index;
 pub mod parser;
+pub mod planner;
 pub mod server;
 pub mod version;
 
 pub use commands::{
-    add_guard, context, context_json, create, decrypt_section, delete_section, diff, diff_documents,
-    diff_file_with_format, encrypt_section, health_report, list_guards, list_snapshots, load, query,
-    query_document, read, read_content_argument, render_context_document, render_context_output,
-    remove_guard, review_commit, review_out, rollback_to_snapshot, save, update, ContextOptions,
-    ContextOutputRequest, CreateOptions, GuardAction, GuardConstraint, HealthReport, OutputFormat,
-    ReadOptions, SnapshotRecord, UpdateOptions,
+    add_guard, context, context_json, create, decrypt_section, delete_section, diff,
+    diff_documents, diff_file_with_format, encrypt_section, health_report, list_guards,
+    list_snapshots, load, query, query_document, read, read_content_argument, remove_guard,
+    render_context_document, render_context_output, review_commit, review_out,
+    rollback_to_snapshot, save, update, ContextOptions, ContextOutputRequest, CreateOptions,
+    GuardAction, GuardConstraint, HealthReport, OutputFormat, ReadOptions, SnapshotRecord,
+    UpdateOptions,
 };
 pub use crypto::EncryptionKey;
 pub use diff::{
@@ -33,6 +35,10 @@ pub use document::{
 };
 pub use export::{export_graph, ExportFormat};
 pub use index::{CachedSectionIndex, SectionIndex};
+pub use planner::{
+    discover_memory_files, plan_memory, PlanOptions, PlanReport, PlanStep, ProofReport, SatBackend,
+    SatStatus,
+};
 pub use version::{
     is_supported_format_version, RBMEM_FORMAT_LABEL, RBMEM_FORMAT_VERSION,
     RBMEM_LEGACY_FORMAT_VERSION,

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,6 +297,19 @@ enum HermesCommand {
         #[arg(long)]
         json_file: Option<PathBuf>,
     },
+    Plan {
+        file: PathBuf,
+        #[arg(long)]
+        goal: Option<String>,
+        #[arg(long)]
+        from_memory: bool,
+        #[arg(long)]
+        pack: Option<String>,
+        #[arg(long)]
+        dry_run: bool,
+        #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+        format: OutputFormat,
+    },
     Init {
         project_name: String,
     },
@@ -835,6 +848,36 @@ fn run() -> Result<(), RbmemError> {
                 write_document(&file, &document, false)?;
                 validate_or_error(&document)?;
                 println!("saved {}", file.display());
+            }
+            HermesCommand::Plan {
+                file,
+                goal,
+                from_memory,
+                pack,
+                dry_run,
+                format,
+            } => {
+                let search_dir = file.parent().map(Path::to_path_buf).unwrap_or_else(|| {
+                    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+                });
+                let report = rbmem::plan_memory(PlanOptions {
+                    goal,
+                    from_memory,
+                    file: Some(file),
+                    search_dir,
+                    context_pack: pack,
+                    solver: SatBackend::Auto,
+                    proof: false,
+                    proof_path: None,
+                    verify_proof: false,
+                    cube_and_conquer: false,
+                    dry_run,
+                    now: Utc::now(),
+                })?;
+                match format {
+                    OutputFormat::Text => print!("{}", render_plan_report(&report)),
+                    OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&report)?),
+                }
             }
             HermesCommand::Init { project_name } => {
                 let now = Utc::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,9 @@ use rbmem::parser::parse_document;
 #[cfg(test)]
 use rbmem::GraphRelation;
 use rbmem::{
-    CompactMode, DiffFormat, InferenceStrategy, MergeStrategy, OutputFormat, RbmemDocument,
-    RbmemError, Section, SectionType, SourceInfo, TimestampPolicy,
+    CompactMode, DiffFormat, InferenceStrategy, MergeStrategy, OutputFormat, PlanOptions,
+    PlanReport, RbmemDocument, RbmemError, SatBackend, SatStatus, Section, SectionType, SourceInfo,
+    TimestampPolicy,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -167,6 +168,29 @@ enum Command {
         format: OutputFormat,
         #[arg(long)]
         decrypt: bool,
+    },
+    Plan {
+        goal: Option<String>,
+        #[arg(long)]
+        file: Option<PathBuf>,
+        #[arg(long)]
+        from_memory: bool,
+        #[arg(long)]
+        pack: Option<String>,
+        #[arg(long, value_enum, default_value_t = SatBackend::Auto)]
+        solver: SatBackend,
+        #[arg(long)]
+        proof: bool,
+        #[arg(long)]
+        proof_path: Option<PathBuf>,
+        #[arg(long)]
+        verify_proof: bool,
+        #[arg(long)]
+        cube_and_conquer: bool,
+        #[arg(long)]
+        dry_run: bool,
+        #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+        format: OutputFormat,
     },
     Encrypt {
         file: PathBuf,
@@ -596,6 +620,38 @@ fn run() -> Result<(), RbmemError> {
                 println!();
             }
         }
+        Command::Plan {
+            goal,
+            file,
+            from_memory,
+            pack,
+            solver,
+            proof,
+            proof_path,
+            verify_proof,
+            cube_and_conquer,
+            dry_run,
+            format,
+        } => {
+            let report = rbmem::plan_memory(PlanOptions {
+                goal,
+                from_memory,
+                file,
+                search_dir: std::env::current_dir().map_err(RbmemError::Io)?,
+                context_pack: pack,
+                solver,
+                proof,
+                proof_path,
+                verify_proof,
+                cube_and_conquer,
+                dry_run,
+                now: Utc::now(),
+            })?;
+            match format {
+                OutputFormat::Text => print!("{}", render_plan_report(&report)),
+                OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&report)?),
+            }
+        }
         Command::Encrypt { file, section } => {
             let key = rbmem::EncryptionKey::resolve()?;
             api::encrypt_section(&file, &section, &key, Utc::now())?;
@@ -831,6 +887,55 @@ fn write_document(path: &Path, document: &RbmemDocument, human: bool) -> Result<
     };
     fs::write(path, text)?;
     Ok(())
+}
+
+fn render_plan_report(report: &PlanReport) -> String {
+    let mut output = String::new();
+    output.push_str("rbmem SAT plan\n");
+    output.push_str(&format!("goal: {}\n", report.goal));
+    output.push_str(&format!("status: {:?}\n", report.status));
+    output.push_str(&format!("solver: {}\n", report.solver));
+    output.push_str(&format!("memory: {}\n", report.memory_file));
+    output.push_str(&format!("stored: {}\n", report.plan_path));
+    output.push_str(&format!(
+        "cnf: {} variable(s), {} clause(s)\n",
+        report.variables, report.clauses
+    ));
+    if report.dry_run {
+        output.push_str("dry-run: plan was not written\n");
+    }
+    if report.proof.requested {
+        output.push_str(&format!(
+            "proof: {} ({}, verified: {})\n",
+            report.proof.path.as_deref().unwrap_or("not written"),
+            report.proof.verifier,
+            report.proof.verified
+        ));
+    }
+
+    match report.status {
+        SatStatus::Sat => {
+            output.push_str("\nsteps:\n");
+            if report.steps.is_empty() {
+                output.push_str("- no concrete steps selected\n");
+            } else {
+                for step in &report.steps {
+                    if let Some(source) = &step.source {
+                        output.push_str(&format!("{}. {} [{}]\n", step.order, step.action, source));
+                    } else {
+                        output.push_str(&format!("{}. {}\n", step.order, step.action));
+                    }
+                }
+            }
+        }
+        SatStatus::Unsat => {
+            output.push_str(
+                "\nNo satisfying plan found. Review conflicting rules and constraints.\n",
+            );
+        }
+    }
+
+    output
 }
 
 fn convert_markdown_to_rbmem(markdown: &str, now: chrono::DateTime<Utc>) -> RbmemDocument {

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -1,0 +1,1434 @@
+//! SAT-backed planning for RBMEM documents.
+//!
+//! The planner turns goals plus durable RBMEM context into a small CNF problem:
+//! candidate actions become Boolean variables, memory rules become clauses, and
+//! the satisfying assignment becomes a plan stored back into the same memory
+//! graph. External Kissat/CaDiCaL binaries are used when available; the internal
+//! DPLL solver keeps the feature usable without extra installation steps.
+
+use crate::document::{
+    GraphInfo, GraphRelation, RbmemDocument, RbmemError, Section, SectionType, SourceInfo,
+    TimestampPolicy,
+};
+use crate::parser::parse_document;
+use chrono::{DateTime, Utc};
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::{BTreeSet, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum SatBackend {
+    Auto,
+    Internal,
+    Kissat,
+    Cadical,
+}
+
+impl std::fmt::Display for SatBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SatBackend::Auto => f.write_str("auto"),
+            SatBackend::Internal => f.write_str("internal"),
+            SatBackend::Kissat => f.write_str("kissat"),
+            SatBackend::Cadical => f.write_str("cadical"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SatStatus {
+    Sat,
+    Unsat,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PlanOptions {
+    pub goal: Option<String>,
+    pub from_memory: bool,
+    pub file: Option<PathBuf>,
+    pub search_dir: PathBuf,
+    pub context_pack: Option<String>,
+    pub solver: SatBackend,
+    pub proof: bool,
+    pub proof_path: Option<PathBuf>,
+    pub verify_proof: bool,
+    pub cube_and_conquer: bool,
+    pub dry_run: bool,
+    pub now: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PlanStep {
+    pub order: usize,
+    pub action: String,
+    pub source: Option<String>,
+    pub score: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProofReport {
+    pub requested: bool,
+    pub path: Option<String>,
+    pub generated: bool,
+    pub verified: bool,
+    pub verifier: String,
+    pub note: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PlanReport {
+    pub schema: String,
+    pub goal: String,
+    pub memory_file: String,
+    pub discovered_files: Vec<String>,
+    pub plan_path: String,
+    pub status: SatStatus,
+    pub solver: String,
+    pub cube_and_conquer: bool,
+    pub variables: usize,
+    pub clauses: usize,
+    pub selected: usize,
+    pub steps: Vec<PlanStep>,
+    pub context_sections: Vec<String>,
+    pub proof: ProofReport,
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone)]
+struct CandidateAction {
+    title: String,
+    text: String,
+    source_path: Option<String>,
+    score: i64,
+}
+
+#[derive(Debug, Clone)]
+struct RuleClause {
+    clause: Vec<i32>,
+}
+
+#[derive(Debug, Clone)]
+struct PlanningProblem {
+    goal: String,
+    candidates: Vec<CandidateAction>,
+    context_sections: Vec<String>,
+    clauses: Vec<RuleClause>,
+    requires: Vec<(usize, usize)>,
+    conflicts: Vec<(usize, usize)>,
+}
+
+#[derive(Debug, Clone)]
+struct SolverResult {
+    status: SatStatus,
+    assignment: Vec<bool>,
+    solver: String,
+}
+
+pub fn plan_memory(options: PlanOptions) -> Result<PlanReport, RbmemError> {
+    let files = discover_memory_files(options.file.as_deref(), &options.search_dir)?;
+    let primary_path = select_primary_file(options.file.as_deref(), &options.search_dir, &files);
+    let mut primary = load_or_create_document(&primary_path, options.now)?;
+
+    let mut context = Vec::new();
+    for file in &files {
+        if file == &primary_path {
+            context.push(primary.clone());
+        } else if let Ok(document) = load_document(file) {
+            context.push(document);
+        }
+    }
+    if context.is_empty() {
+        context.push(primary.clone());
+    }
+    if let Some(pack_name) = &options.context_pack {
+        let includes = load_context_pack(&primary_path, &options.search_dir, pack_name)?;
+        context = filter_context_for_pack(context, &includes);
+    }
+
+    let problem = build_problem(&context, options.goal.as_deref(), options.from_memory)?;
+    let mut solve = solve_problem(&problem, options.solver, options.cube_and_conquer)?;
+    if solve.status == SatStatus::Sat {
+        minimize_assignment(&problem, &mut solve.assignment);
+    }
+    let selected_indices = selected_indices(&solve.assignment, &problem.candidates);
+    let steps = order_steps(&problem, &selected_indices);
+    let plan_slug = plan_slug(&problem.goal, options.now);
+    let plan_path = format!("plans.{plan_slug}");
+    let dimacs = dimacs_string(problem.candidates.len(), &problem.clauses);
+
+    let proof = handle_proof(
+        &problem,
+        &solve,
+        &dimacs,
+        &primary_path,
+        &plan_slug,
+        &options,
+    )?;
+
+    if !options.dry_run {
+        persist_plan(
+            &mut primary,
+            &primary_path,
+            &problem,
+            &solve,
+            &steps,
+            &proof,
+            &plan_path,
+            &dimacs,
+            options.now,
+        )?;
+    }
+
+    Ok(PlanReport {
+        schema: "rbmem.plan.v1".to_string(),
+        goal: problem.goal,
+        memory_file: primary_path.display().to_string(),
+        discovered_files: files
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect(),
+        plan_path,
+        status: solve.status,
+        solver: solve.solver,
+        cube_and_conquer: options.cube_and_conquer,
+        variables: problem.candidates.len(),
+        clauses: problem.clauses.len(),
+        selected: steps.len(),
+        steps,
+        context_sections: problem.context_sections,
+        proof,
+        dry_run: options.dry_run,
+    })
+}
+
+pub fn discover_memory_files(
+    explicit: Option<&Path>,
+    search_dir: &Path,
+) -> Result<Vec<PathBuf>, RbmemError> {
+    if let Some(path) = explicit {
+        return Ok(vec![path.to_path_buf()]);
+    }
+
+    let mut files = Vec::new();
+    if search_dir.exists() {
+        for entry in fs::read_dir(search_dir)? {
+            let path = entry?.path();
+            if path.extension().and_then(|ext| ext.to_str()) == Some("rbmem") {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn select_primary_file(explicit: Option<&Path>, search_dir: &Path, files: &[PathBuf]) -> PathBuf {
+    if let Some(path) = explicit {
+        return path.to_path_buf();
+    }
+
+    for preferred in ["memory.rbmem", "MEMORY.rbmem", "my-agent-memory.rbmem"] {
+        let candidate = search_dir.join(preferred);
+        if files.iter().any(|path| same_path(path, &candidate)) {
+            return candidate;
+        }
+    }
+
+    files
+        .first()
+        .cloned()
+        .unwrap_or_else(|| search_dir.join("memory.rbmem"))
+}
+
+fn same_path(left: &Path, right: &Path) -> bool {
+    left.file_name() == right.file_name() && left.parent() == right.parent()
+}
+
+fn load_or_create_document(path: &Path, now: DateTime<Utc>) -> Result<RbmemDocument, RbmemError> {
+    if path.exists() {
+        load_document(path)
+    } else {
+        let mut document = RbmemDocument::new(now, "planner");
+        document.meta.purpose = "personal-agent-memory".to_string();
+        Ok(document)
+    }
+}
+
+fn load_document(path: &Path) -> Result<RbmemDocument, RbmemError> {
+    Ok(parse_document(&fs::read_to_string(path)?, TimestampPolicy::Preserve)?.document)
+}
+
+fn load_context_pack(
+    primary_path: &Path,
+    search_dir: &Path,
+    name: &str,
+) -> Result<BTreeSet<String>, RbmemError> {
+    let candidates = [
+        primary_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(".rbmempacks"),
+        search_dir.join(".rbmempacks"),
+    ];
+
+    for path in candidates {
+        if !path.exists() {
+            continue;
+        }
+        let text = fs::read_to_string(&path)?;
+        if let Some(includes) = parse_context_pack_includes(&text, name) {
+            return Ok(includes);
+        }
+    }
+
+    Err(RbmemError::NotFound(format!(
+        "context pack '{name}' not found"
+    )))
+}
+
+fn parse_context_pack_includes(text: &str, name: &str) -> Option<BTreeSet<String>> {
+    let header = format!("[pack: {name}]");
+    let mut in_pack = false;
+    let mut in_include = false;
+    let mut includes = BTreeSet::new();
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("[pack:") {
+            if in_pack {
+                break;
+            }
+            in_pack = trimmed == header;
+            in_include = false;
+            continue;
+        }
+        if !in_pack {
+            continue;
+        }
+        if trimmed == "include:" {
+            in_include = true;
+            continue;
+        }
+        if trimmed.ends_with(':') && trimmed != "include:" {
+            in_include = false;
+            continue;
+        }
+        if in_include {
+            if let Some(path) = trimmed.strip_prefix("- ") {
+                includes.insert(path.trim().to_string());
+            }
+        }
+    }
+
+    in_pack.then_some(includes)
+}
+
+fn filter_context_for_pack(
+    mut documents: Vec<RbmemDocument>,
+    includes: &BTreeSet<String>,
+) -> Vec<RbmemDocument> {
+    if includes.is_empty() {
+        return documents;
+    }
+
+    for document in &mut documents {
+        document.sections.retain(|section| {
+            is_planning_context(section)
+                || includes.iter().any(|include| {
+                    section.path == *include || section.path.starts_with(&format!("{include}."))
+                })
+        });
+    }
+    documents
+}
+
+fn build_problem(
+    documents: &[RbmemDocument],
+    explicit_goal: Option<&str>,
+    from_memory: bool,
+) -> Result<PlanningProblem, RbmemError> {
+    let goal = explicit_goal
+        .map(str::trim)
+        .filter(|goal| !goal.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| {
+            from_memory
+                .then(|| derive_goal_from_memory(documents))
+                .flatten()
+        })
+        .ok_or_else(|| {
+            RbmemError::Parse(
+                "missing goal; pass rbmem plan \"<goal>\" or --from-memory".to_string(),
+            )
+        })?;
+
+    let mut candidates = extract_candidates(documents, &goal);
+    if candidates.is_empty() {
+        candidates.push(CandidateAction {
+            title: format!("Work toward: {goal}"),
+            text: goal.clone(),
+            source_path: None,
+            score: 10,
+        });
+    }
+
+    rank_candidates(&mut candidates, &goal);
+    let mut clauses = Vec::new();
+    add_goal_clause(&mut clauses, &candidates, &goal);
+
+    let mut requires = Vec::new();
+    let mut conflicts = Vec::new();
+    for section in documents.iter().flat_map(|document| &document.sections) {
+        apply_section_rules(
+            section,
+            &candidates,
+            &mut clauses,
+            &mut requires,
+            &mut conflicts,
+        );
+    }
+
+    let context_sections = documents
+        .iter()
+        .flat_map(|document| &document.sections)
+        .filter(|section| is_planning_context(section))
+        .map(|section| section.path.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    Ok(PlanningProblem {
+        goal,
+        candidates,
+        context_sections,
+        clauses,
+        requires,
+        conflicts,
+    })
+}
+
+fn derive_goal_from_memory(documents: &[RbmemDocument]) -> Option<String> {
+    for section in documents.iter().flat_map(|document| &document.sections) {
+        if !section.path.contains("goal") && !section.path.contains("task") {
+            continue;
+        }
+        for line in section.content.lines() {
+            if let Some(item) = bullet_text(line) {
+                if !item.is_empty() {
+                    return Some(item);
+                }
+            }
+        }
+        let content = section.content.trim();
+        if !content.is_empty() {
+            return Some(first_sentence(content));
+        }
+    }
+    None
+}
+
+fn extract_candidates(documents: &[RbmemDocument], goal: &str) -> Vec<CandidateAction> {
+    let mut seen = BTreeSet::new();
+    let mut candidates = Vec::new();
+
+    for section in documents.iter().flat_map(|document| &document.sections) {
+        if section.section_type == SectionType::Encrypted {
+            continue;
+        }
+
+        let path_relevant = path_has_any(
+            &section.path,
+            &[
+                "action", "actions", "task", "tasks", "step", "steps", "goal", "plan",
+            ],
+        );
+
+        if path_relevant {
+            for line in section.content.lines() {
+                if let Some(item) = bullet_text(line) {
+                    if item.len() < 4 {
+                        continue;
+                    }
+                    let normalized = normalize(&item);
+                    if seen.insert(normalized) {
+                        candidates.push(CandidateAction {
+                            title: item.clone(),
+                            text: format!("{}\n{}", section.path, section.content),
+                            source_path: Some(section.path.clone()),
+                            score: 4,
+                        });
+                    }
+                }
+            }
+        }
+
+        if path_relevant && !section.content.trim().is_empty() {
+            let title = first_sentence(&section.content);
+            let normalized = normalize(&title);
+            if seen.insert(normalized) {
+                candidates.push(CandidateAction {
+                    title,
+                    text: section.content.clone(),
+                    source_path: Some(section.path.clone()),
+                    score: 3,
+                });
+            }
+        }
+    }
+
+    if !candidates
+        .iter()
+        .any(|candidate| overlap_score(&candidate.title, goal) > 0)
+    {
+        candidates.push(CandidateAction {
+            title: format!("Satisfy goal: {goal}"),
+            text: goal.to_string(),
+            source_path: None,
+            score: 8,
+        });
+    }
+
+    candidates
+}
+
+fn rank_candidates(candidates: &mut [CandidateAction], goal: &str) {
+    for candidate in candidates {
+        candidate.score += overlap_score(&candidate.title, goal) as i64 * 4;
+        candidate.score += overlap_score(&candidate.text, goal) as i64;
+    }
+}
+
+fn add_goal_clause(clauses: &mut Vec<RuleClause>, candidates: &[CandidateAction], goal: &str) {
+    let threshold = phrase_threshold(goal);
+    let mut vars = candidates
+        .iter()
+        .enumerate()
+        .filter_map(|(index, candidate)| {
+            (overlap_score(&candidate.title, goal) >= threshold).then_some((index + 1) as i32)
+        })
+        .collect::<Vec<_>>();
+
+    if vars.is_empty() {
+        vars = candidates
+            .iter()
+            .enumerate()
+            .filter_map(|(index, candidate)| {
+                (overlap_score(&candidate.text, goal) > 1).then_some((index + 1) as i32)
+            })
+            .collect();
+    }
+
+    if vars.is_empty() {
+        vars = (1..=candidates.len()).map(|index| index as i32).collect();
+    }
+
+    if !vars.is_empty() {
+        clauses.push(RuleClause { clause: vars });
+    }
+}
+
+fn apply_section_rules(
+    section: &Section,
+    candidates: &[CandidateAction],
+    clauses: &mut Vec<RuleClause>,
+    requires: &mut Vec<(usize, usize)>,
+    conflicts: &mut Vec<(usize, usize)>,
+) {
+    if !is_planning_context(section) {
+        return;
+    }
+
+    for line in section
+        .content
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+    {
+        let normalized = normalize(line);
+        if let Some((left, right)) = parse_requires(&normalized) {
+            for a in matching_candidates(candidates, &left) {
+                for b in matching_candidates(candidates, &right) {
+                    if a != b {
+                        clauses.push(RuleClause {
+                            clause: vec![-((a + 1) as i32), (b + 1) as i32],
+                        });
+                        requires.push((a, b));
+                    }
+                }
+            }
+            continue;
+        }
+
+        if let Some((left, right)) = parse_conflict(&normalized) {
+            for a in matching_candidates(candidates, &left) {
+                for b in matching_candidates(candidates, &right) {
+                    if a != b {
+                        clauses.push(RuleClause {
+                            clause: vec![-((a + 1) as i32), -((b + 1) as i32)],
+                        });
+                        conflicts.push((a, b));
+                    }
+                }
+            }
+            continue;
+        }
+
+        if starts_with_any(&normalized, &["must ", "always ", "include ", "required "]) {
+            for index in matching_candidates(candidates, strip_rule_prefix(&normalized)) {
+                clauses.push(RuleClause {
+                    clause: vec![(index + 1) as i32],
+                });
+            }
+        }
+
+        if starts_with_any(
+            &normalized,
+            &[
+                "avoid ",
+                "never ",
+                "do not ",
+                "dont ",
+                "exclude ",
+                "prohibit ",
+            ],
+        ) {
+            for index in matching_candidates(candidates, strip_rule_prefix(&normalized)) {
+                clauses.push(RuleClause {
+                    clause: vec![-((index + 1) as i32)],
+                });
+            }
+        }
+    }
+}
+
+fn is_planning_context(section: &Section) -> bool {
+    path_has_any(
+        &section.path,
+        &[
+            "rule",
+            "rules",
+            "constraint",
+            "constraints",
+            "preference",
+            "preferences",
+            "guard",
+            "guards",
+            "task",
+            "tasks",
+            "goal",
+            "goals",
+            "plan",
+            "plans",
+            "context",
+        ],
+    )
+}
+
+fn parse_requires(line: &str) -> Option<(String, String)> {
+    if let Some((left, right)) = line.split_once(" requires ") {
+        return Some((clean_rule_side(left), clean_rule_side(right)));
+    }
+    if let Some((left, right)) = line.split_once(" depends on ") {
+        return Some((clean_rule_side(left), clean_rule_side(right)));
+    }
+    if let Some((left, right)) = line.split_once(" after ") {
+        return Some((clean_rule_side(left), clean_rule_side(right)));
+    }
+    if line.starts_with("requires ") || line.starts_with("require ") {
+        if let Some((left, right)) = line.split_once(" -> ") {
+            return Some((clean_rule_side(left), clean_rule_side(right)));
+        }
+    }
+    None
+}
+
+fn parse_conflict(line: &str) -> Option<(String, String)> {
+    for marker in [
+        " conflicts with ",
+        " cannot combine with ",
+        " cannot run with ",
+        " not with ",
+        " mutually exclusive with ",
+    ] {
+        if let Some((left, right)) = line.split_once(marker) {
+            return Some((clean_rule_side(left), clean_rule_side(right)));
+        }
+    }
+    None
+}
+
+fn clean_rule_side(value: &str) -> String {
+    strip_rule_prefix(value)
+        .trim_matches(|ch: char| !ch.is_ascii_alphanumeric() && ch != ' ')
+        .trim()
+        .to_string()
+}
+
+fn strip_rule_prefix(value: &str) -> &str {
+    for prefix in [
+        "- ",
+        "* ",
+        "must ",
+        "always ",
+        "include ",
+        "required ",
+        "requires ",
+        "require ",
+        "avoid ",
+        "never ",
+        "do not ",
+        "dont ",
+        "exclude ",
+        "prohibit ",
+        "prefer ",
+        "prioritize ",
+    ] {
+        if let Some(rest) = value.strip_prefix(prefix) {
+            return rest;
+        }
+    }
+    value
+}
+
+fn matching_candidates(candidates: &[CandidateAction], phrase: &str) -> Vec<usize> {
+    let phrase = normalize(phrase);
+    if phrase.len() < 3 {
+        return Vec::new();
+    }
+    let threshold = phrase_threshold(&phrase);
+
+    let mut scored = candidates
+        .iter()
+        .enumerate()
+        .filter_map(|(index, candidate)| {
+            let haystack = normalize(&candidate.title);
+            let score = if haystack.contains(&phrase) {
+                100
+            } else {
+                overlap_score(&haystack, &phrase)
+            };
+            (score >= threshold).then_some((index, score))
+        })
+        .collect::<Vec<_>>();
+    scored.sort_by(|left, right| right.1.cmp(&left.1));
+    if !scored.is_empty() {
+        return scored.into_iter().take(3).map(|(index, _)| index).collect();
+    }
+
+    let mut scored = candidates
+        .iter()
+        .enumerate()
+        .filter_map(|(index, candidate)| {
+            let haystack = normalize(&candidate.text);
+            let score = if haystack.contains(&phrase) {
+                50
+            } else {
+                overlap_score(&haystack, &phrase)
+            };
+            (score >= threshold).then_some((index, score))
+        })
+        .collect::<Vec<_>>();
+    scored.sort_by(|left, right| right.1.cmp(&left.1));
+    scored.into_iter().take(3).map(|(index, _)| index).collect()
+}
+
+fn phrase_threshold(phrase: &str) -> usize {
+    let count = terms(phrase).len();
+    if count <= 1 {
+        1
+    } else {
+        2
+    }
+}
+
+fn solve_problem(
+    problem: &PlanningProblem,
+    backend: SatBackend,
+    cube_and_conquer: bool,
+) -> Result<SolverResult, RbmemError> {
+    if cube_and_conquer {
+        return solve_cube_and_conquer(problem, backend);
+    }
+
+    match backend {
+        SatBackend::Kissat => {
+            solve_external(problem, "kissat").or_else(|_| solve_internal(problem))
+        }
+        SatBackend::Cadical => {
+            solve_external(problem, "cadical").or_else(|_| solve_internal(problem))
+        }
+        SatBackend::Auto => solve_external(problem, "kissat")
+            .or_else(|_| solve_external(problem, "cadical"))
+            .or_else(|_| solve_internal(problem)),
+        SatBackend::Internal => solve_internal(problem),
+    }
+}
+
+fn solve_cube_and_conquer(
+    problem: &PlanningProblem,
+    backend: SatBackend,
+) -> Result<SolverResult, RbmemError> {
+    let cube_vars = problem.candidates.len().min(3);
+    if cube_vars == 0 {
+        return solve_internal(problem);
+    }
+
+    for mask in 0..(1usize << cube_vars) {
+        let mut cubed = problem.clone();
+        for index in 0..cube_vars {
+            let var = (index + 1) as i32;
+            let lit = if (mask & (1 << index)) != 0 {
+                var
+            } else {
+                -var
+            };
+            cubed.clauses.push(RuleClause { clause: vec![lit] });
+        }
+        let result = solve_problem(&cubed, backend_without_cube(backend), false)?;
+        if result.status == SatStatus::Sat {
+            return Ok(SolverResult {
+                solver: format!("cube-and-conquer+{}", result.solver),
+                ..result
+            });
+        }
+    }
+
+    Ok(SolverResult {
+        status: SatStatus::Unsat,
+        assignment: vec![false; problem.candidates.len() + 1],
+        solver: "cube-and-conquer+internal".to_string(),
+    })
+}
+
+fn backend_without_cube(backend: SatBackend) -> SatBackend {
+    match backend {
+        SatBackend::Auto | SatBackend::Kissat | SatBackend::Cadical => backend,
+        SatBackend::Internal => SatBackend::Internal,
+    }
+}
+
+fn solve_external(problem: &PlanningProblem, binary: &str) -> Result<SolverResult, RbmemError> {
+    let dimacs = dimacs_string(problem.candidates.len(), &problem.clauses);
+    let path = std::env::temp_dir().join(format!(
+        "rbmem-plan-{}-{}.cnf",
+        std::process::id(),
+        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    ));
+    fs::write(&path, dimacs)?;
+
+    let output = Command::new(binary).arg(&path).output();
+    let _ = fs::remove_file(&path);
+    let output = output.map_err(|error| RbmemError::Parse(error.to_string()))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let text = format!("{stdout}\n{stderr}");
+
+    if text.contains("UNSATISFIABLE") {
+        return Ok(SolverResult {
+            status: SatStatus::Unsat,
+            assignment: vec![false; problem.candidates.len() + 1],
+            solver: binary.to_string(),
+        });
+    }
+
+    if text.contains("SATISFIABLE") {
+        let mut assignment = vec![false; problem.candidates.len() + 1];
+        for token in text.split_whitespace() {
+            if let Ok(lit) = token.parse::<i32>() {
+                if lit > 0 && (lit as usize) < assignment.len() {
+                    assignment[lit as usize] = true;
+                }
+            }
+        }
+        return Ok(SolverResult {
+            status: SatStatus::Sat,
+            assignment,
+            solver: binary.to_string(),
+        });
+    }
+
+    Err(RbmemError::Parse(format!(
+        "{binary} did not return a SAT status"
+    )))
+}
+
+fn solve_internal(problem: &PlanningProblem) -> Result<SolverResult, RbmemError> {
+    let mut assignment = vec![None; problem.candidates.len() + 1];
+    let clauses = problem
+        .clauses
+        .iter()
+        .map(|rule| rule.clause.clone())
+        .collect::<Vec<_>>();
+    let status = dpll(&clauses, &mut assignment);
+    let concrete = assignment
+        .into_iter()
+        .map(|value| value.unwrap_or(false))
+        .collect::<Vec<_>>();
+    Ok(SolverResult {
+        status: if status {
+            SatStatus::Sat
+        } else {
+            SatStatus::Unsat
+        },
+        assignment: concrete,
+        solver: "internal-dpll".to_string(),
+    })
+}
+
+fn dpll(clauses: &[Vec<i32>], assignment: &mut [Option<bool>]) -> bool {
+    loop {
+        let mut changed = false;
+        for clause in clauses {
+            match eval_clause(clause, assignment) {
+                ClauseEval::Satisfied => {}
+                ClauseEval::Conflict => return false,
+                ClauseEval::Unit(lit) => {
+                    let var = lit.unsigned_abs() as usize;
+                    let value = lit > 0;
+                    if let Some(existing) = assignment[var] {
+                        if existing != value {
+                            return false;
+                        }
+                    } else {
+                        assignment[var] = Some(value);
+                        changed = true;
+                    }
+                }
+                ClauseEval::Open => {}
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    if clauses
+        .iter()
+        .all(|clause| matches!(eval_clause(clause, assignment), ClauseEval::Satisfied))
+    {
+        return true;
+    }
+
+    let var = assignment.iter().position(Option::is_none);
+    let Some(var) = var else {
+        return false;
+    };
+    for value in [true, false] {
+        let mut next = assignment.to_vec();
+        next[var] = Some(value);
+        if dpll(clauses, &mut next) {
+            assignment.copy_from_slice(&next);
+            return true;
+        }
+    }
+    false
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClauseEval {
+    Satisfied,
+    Conflict,
+    Unit(i32),
+    Open,
+}
+
+fn eval_clause(clause: &[i32], assignment: &[Option<bool>]) -> ClauseEval {
+    let mut unassigned = None;
+    let mut unassigned_count = 0;
+
+    for &lit in clause {
+        let var = lit.unsigned_abs() as usize;
+        match assignment.get(var).copied().flatten() {
+            Some(value) if value == (lit > 0) => return ClauseEval::Satisfied,
+            Some(_) => {}
+            None => {
+                unassigned = Some(lit);
+                unassigned_count += 1;
+            }
+        }
+    }
+
+    match unassigned_count {
+        0 => ClauseEval::Conflict,
+        1 => ClauseEval::Unit(unassigned.unwrap_or(0)),
+        _ => ClauseEval::Open,
+    }
+}
+
+fn selected_indices(assignment: &[bool], candidates: &[CandidateAction]) -> Vec<usize> {
+    let mut selected = candidates
+        .iter()
+        .enumerate()
+        .filter_map(|(index, candidate)| {
+            assignment
+                .get(index + 1)
+                .copied()
+                .unwrap_or(false)
+                .then_some((index, candidate.score))
+        })
+        .collect::<Vec<_>>();
+    selected.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+    selected.into_iter().map(|(index, _)| index).collect()
+}
+
+fn minimize_assignment(problem: &PlanningProblem, assignment: &mut [bool]) {
+    let mut selected = problem
+        .candidates
+        .iter()
+        .enumerate()
+        .filter_map(|(index, candidate)| {
+            assignment
+                .get(index + 1)
+                .copied()
+                .unwrap_or(false)
+                .then_some((index + 1, candidate.score))
+        })
+        .collect::<Vec<_>>();
+    selected.sort_by(|left, right| left.1.cmp(&right.1).then_with(|| left.0.cmp(&right.0)));
+
+    for (var, _) in selected {
+        assignment[var] = false;
+        if !assignment_satisfies(problem, assignment) {
+            assignment[var] = true;
+        }
+    }
+}
+
+fn assignment_satisfies(problem: &PlanningProblem, assignment: &[bool]) -> bool {
+    problem.clauses.iter().all(|rule| {
+        rule.clause.iter().any(|lit| {
+            let var = lit.unsigned_abs() as usize;
+            assignment.get(var).copied().unwrap_or(false) == (*lit > 0)
+        })
+    })
+}
+
+fn order_steps(problem: &PlanningProblem, selected: &[usize]) -> Vec<PlanStep> {
+    let selected_set = selected.iter().copied().collect::<BTreeSet<_>>();
+    let mut indegree = HashMap::<usize, usize>::new();
+    let mut outgoing = HashMap::<usize, Vec<usize>>::new();
+
+    for &(action, prerequisite) in &problem.requires {
+        if selected_set.contains(&action) && selected_set.contains(&prerequisite) {
+            *indegree.entry(action).or_default() += 1;
+            outgoing.entry(prerequisite).or_default().push(action);
+        }
+    }
+
+    let mut ready = selected
+        .iter()
+        .copied()
+        .filter(|index| indegree.get(index).copied().unwrap_or(0) == 0)
+        .collect::<Vec<_>>();
+    ready.sort_by(|left, right| {
+        problem.candidates[*right]
+            .score
+            .cmp(&problem.candidates[*left].score)
+            .then_with(|| left.cmp(right))
+    });
+
+    let mut ordered = Vec::new();
+    let mut seen = BTreeSet::new();
+    while let Some(index) = ready.pop() {
+        if !seen.insert(index) {
+            continue;
+        }
+        ordered.push(index);
+        if let Some(children) = outgoing.get(&index) {
+            for &child in children {
+                let entry = indegree.entry(child).or_default();
+                *entry = entry.saturating_sub(1);
+                if *entry == 0 {
+                    ready.push(child);
+                }
+            }
+        }
+    }
+
+    for &index in selected {
+        if seen.insert(index) {
+            ordered.push(index);
+        }
+    }
+
+    ordered
+        .into_iter()
+        .enumerate()
+        .map(|(order, index)| PlanStep {
+            order: order + 1,
+            action: problem.candidates[index].title.clone(),
+            source: problem.candidates[index].source_path.clone(),
+            score: problem.candidates[index].score,
+        })
+        .collect()
+}
+
+fn handle_proof(
+    problem: &PlanningProblem,
+    solve: &SolverResult,
+    dimacs: &str,
+    primary_path: &Path,
+    plan_slug: &str,
+    options: &PlanOptions,
+) -> Result<ProofReport, RbmemError> {
+    if !options.proof {
+        return Ok(ProofReport {
+            requested: false,
+            path: None,
+            generated: false,
+            verified: false,
+            verifier: "none".to_string(),
+            note: "proof generation not requested".to_string(),
+        });
+    }
+
+    let proof_path = options.proof_path.clone().unwrap_or_else(|| {
+        primary_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(".rbmem")
+            .join("plans")
+            .join(format!("{plan_slug}.drat"))
+    });
+
+    if let Some(parent) = proof_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let note = if solve.status == SatStatus::Unsat && contains_empty_clause(problem) {
+        fs::write(&proof_path, "0\n")?;
+        "generated internal empty-clause DRAT proof".to_string()
+    } else if solve.status == SatStatus::Unsat {
+        fs::write(&proof_path, "")?;
+        "UNSAT found; install Kissat/CaDiCaL plus drat-trim for full DRAT traces".to_string()
+    } else {
+        fs::write(&proof_path, "")?;
+        "SAT plans do not have UNSAT DRAT proofs; DIMACS and model are stored in RBMEM".to_string()
+    };
+
+    let (verified, verifier) = if options.verify_proof {
+        verify_proof(dimacs, &proof_path)
+    } else {
+        (false, "not-requested".to_string())
+    };
+
+    Ok(ProofReport {
+        requested: true,
+        path: Some(proof_path.display().to_string()),
+        generated: true,
+        verified,
+        verifier,
+        note,
+    })
+}
+
+fn contains_empty_clause(problem: &PlanningProblem) -> bool {
+    problem
+        .clauses
+        .iter()
+        .any(|clause| clause.clause.is_empty())
+}
+
+fn verify_proof(dimacs: &str, proof_path: &Path) -> (bool, String) {
+    if let Ok(output) = Command::new("drat-trim").arg("-").arg(proof_path).output() {
+        let text = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        if output.status.success() || text.to_ascii_uppercase().contains("VERIFIED") {
+            return (true, "drat-trim".to_string());
+        }
+    }
+
+    let proof = fs::read_to_string(proof_path).unwrap_or_default();
+    let verified = proof.lines().any(|line| line.trim() == "0") && dimacs.contains(" 0\n");
+    (verified, "internal-empty-clause-check".to_string())
+}
+
+fn persist_plan(
+    document: &mut RbmemDocument,
+    path: &Path,
+    problem: &PlanningProblem,
+    solve: &SolverResult,
+    steps: &[PlanStep],
+    proof: &ProofReport,
+    plan_path: &str,
+    dimacs: &str,
+    now: DateTime<Utc>,
+) -> Result<(), RbmemError> {
+    let goal_path = format!("{plan_path}.goal");
+    let steps_path = format!("{plan_path}.steps");
+    let sat_path = format!("{plan_path}.sat");
+    let proof_path = format!("{plan_path}.proof");
+
+    document.upsert_section(&goal_path, SectionType::Text, problem.goal.clone(), now);
+    document.upsert_section(&steps_path, SectionType::List, render_steps(steps), now);
+    document.upsert_section(
+        &sat_path,
+        SectionType::Json,
+        serde_json::to_string_pretty(&json!({
+            "schema": "rbmem.plan.sat.v1",
+            "status": solve.status,
+            "solver": solve.solver,
+            "variables": problem.candidates.len(),
+            "clauses": problem.clauses.len(),
+            "cube_and_conquer": solve.solver.contains("cube-and-conquer"),
+            "selected_variables": steps.iter().map(|step| step.order).collect::<Vec<_>>(),
+            "conflicts": problem.conflicts.len(),
+            "requires": problem.requires.len(),
+            "dimacs": dimacs,
+        }))?,
+        now,
+    );
+    document.upsert_section(
+        &proof_path,
+        SectionType::Json,
+        serde_json::to_string_pretty(proof)?,
+        now,
+    );
+    document.upsert_section(
+        "timeline",
+        SectionType::Timeline,
+        format!(
+            "{}: SAT plan '{}' produced {:?} with {} step(s).",
+            now.to_rfc3339(),
+            problem.goal,
+            solve.status,
+            steps.len()
+        ),
+        now,
+    );
+
+    set_planner_section_metadata(
+        document,
+        &goal_path,
+        "plan_goal",
+        vec![
+            relation(&steps_path, "has_steps", now),
+            relation(&sat_path, "encoded_as", now),
+        ],
+        now,
+    );
+    let mut step_relations = Vec::new();
+    for source in steps.iter().filter_map(|step| step.source.as_deref()) {
+        step_relations.push(relation(source, "uses_context", now));
+    }
+    set_planner_section_metadata(document, &steps_path, "plan_steps", step_relations, now);
+    set_planner_section_metadata(
+        document,
+        &sat_path,
+        "sat_problem",
+        vec![
+            relation(&goal_path, "solves", now),
+            relation(&proof_path, "has_proof", now),
+        ],
+        now,
+    );
+    set_planner_section_metadata(
+        document,
+        &proof_path,
+        "sat_proof",
+        vec![relation(&sat_path, "verifies", now)],
+        now,
+    );
+
+    fs::write(path, document.to_rbmem_string())?;
+    Ok(())
+}
+
+fn relation(to: &str, relation_type: &str, now: DateTime<Utc>) -> GraphRelation {
+    GraphRelation {
+        to: to.to_string(),
+        relation_type: relation_type.to_string(),
+        valid_from: Some(now),
+        valid_until: None,
+        inferred: false,
+        confidence: None,
+    }
+}
+
+fn set_planner_section_metadata(
+    document: &mut RbmemDocument,
+    path: &str,
+    node_type: &str,
+    relations: Vec<GraphRelation>,
+    now: DateTime<Utc>,
+) {
+    if let Some(section) = document
+        .sections
+        .iter_mut()
+        .find(|section| section.path == path)
+    {
+        section.source = Some(SourceInfo {
+            kind: "planner".to_string(),
+            path: None,
+            actor: Some("rbmem plan".to_string()),
+            hash: None,
+        });
+        section.graph = Some(GraphInfo {
+            node_type: Some(node_type.to_string()),
+            relations,
+        });
+        section.temporal.updated_at = now;
+    }
+}
+
+fn render_steps(steps: &[PlanStep]) -> String {
+    if steps.is_empty() {
+        return "- No satisfying plan was found.".to_string();
+    }
+
+    steps
+        .iter()
+        .map(|step| match &step.source {
+            Some(source) => format!("- {}. {} (source: {})", step.order, step.action, source),
+            None => format!("- {}. {}", step.order, step.action),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn dimacs_string(vars: usize, clauses: &[RuleClause]) -> String {
+    let mut output = format!("p cnf {} {}\n", vars, clauses.len());
+    for clause in clauses {
+        for lit in &clause.clause {
+            output.push_str(&format!("{lit} "));
+        }
+        output.push_str("0\n");
+    }
+    output
+}
+
+fn plan_slug(goal: &str, now: DateTime<Utc>) -> String {
+    let base = normalize(goal)
+        .split_whitespace()
+        .take(6)
+        .collect::<Vec<_>>()
+        .join("-");
+    let base = if base.is_empty() {
+        "goal".to_string()
+    } else {
+        base
+    };
+    format!("{}-{}", base, now.format("%Y%m%d%H%M%S"))
+}
+
+fn bullet_text(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    let item = trimmed
+        .strip_prefix("- [ ] ")
+        .or_else(|| trimmed.strip_prefix("- [x] "))
+        .or_else(|| trimmed.strip_prefix("- "))
+        .or_else(|| trimmed.strip_prefix("* "))
+        .or_else(|| {
+            let (number, rest) = trimmed.split_once(". ")?;
+            number.chars().all(|ch| ch.is_ascii_digit()).then_some(rest)
+        })?;
+    Some(item.trim().to_string())
+}
+
+fn first_sentence(content: &str) -> String {
+    content
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or(content)
+        .trim_end_matches('.')
+        .to_string()
+}
+
+fn overlap_score(left: &str, right: &str) -> usize {
+    let left_terms = terms(left);
+    let right_terms = terms(right);
+    left_terms.intersection(&right_terms).count()
+}
+
+fn terms(text: &str) -> BTreeSet<String> {
+    normalize(text)
+        .split_whitespace()
+        .filter(|term| term.len() > 2)
+        .filter(|term| !STOP_WORDS.contains(term))
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn normalize(text: &str) -> String {
+    let mut output = String::new();
+    let mut last_space = true;
+    for ch in text.chars() {
+        if ch.is_ascii_alphanumeric() {
+            output.push(ch.to_ascii_lowercase());
+            last_space = false;
+        } else if !last_space {
+            output.push(' ');
+            last_space = true;
+        }
+    }
+    output.trim().to_string()
+}
+
+fn path_has_any(path: &str, needles: &[&str]) -> bool {
+    let normalized = normalize(path);
+    needles
+        .iter()
+        .any(|needle| normalized.split_whitespace().any(|part| part == *needle))
+}
+
+fn starts_with_any(value: &str, prefixes: &[&str]) -> bool {
+    prefixes.iter().any(|prefix| value.starts_with(prefix))
+}
+
+const STOP_WORDS: &[&str] = &[
+    "the", "and", "for", "with", "this", "that", "from", "into", "your", "you", "are", "was",
+    "were", "have", "has", "had", "will", "shall", "should", "must", "need", "needs", "goal",
+    "task", "plan", "step", "agent", "memory",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn fixed_time() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 18, 20, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn internal_solver_respects_requires_and_conflicts() {
+        let now = fixed_time();
+        let mut doc = RbmemDocument::new(now, "test");
+        doc.upsert_section(
+            "tasks",
+            SectionType::List,
+            "- Gather requirements\n- Run tests\n- Deploy release".to_string(),
+            now,
+        );
+        doc.upsert_section(
+            "rules",
+            SectionType::List,
+            "- deploy release requires run tests\n- gather requirements conflicts with deploy release".to_string(),
+            now,
+        );
+
+        let problem = build_problem(&[doc], Some("deploy release"), false).unwrap();
+        let result = solve_internal(&problem).unwrap();
+        let selected = selected_indices(&result.assignment, &problem.candidates);
+        let steps = order_steps(&problem, &selected);
+
+        assert_eq!(result.status, SatStatus::Sat);
+        assert!(steps.iter().any(|step| step.action.contains("Run tests")));
+        assert!(steps
+            .iter()
+            .any(|step| step.action.contains("Deploy release")));
+        assert!(!steps
+            .iter()
+            .any(|step| step.action.contains("Gather requirements")));
+    }
+}

--- a/tests/rbmem_api.rs
+++ b/tests/rbmem_api.rs
@@ -38,7 +38,7 @@ fn public_api_create_update_read_query_and_context() {
     let updated = update(
         &file,
         UpdateOptions {
-        actor: "test".to_string(),
+            actor: "test".to_string(),
             section: "agents.reader".to_string(),
             section_type: SectionType::Text,
             content: "Reads memory carefully for github code review.".to_string(),
@@ -125,7 +125,7 @@ fn public_api_update_dry_run_and_delete_section() {
     update(
         &file,
         UpdateOptions {
-        actor: "test".to_string(),
+            actor: "test".to_string(),
             section: "scratch".to_string(),
             section_type: SectionType::Text,
             content: "not persisted".to_string(),
@@ -140,7 +140,7 @@ fn public_api_update_dry_run_and_delete_section() {
     update(
         &file,
         UpdateOptions {
-        actor: "test".to_string(),
+            actor: "test".to_string(),
             section: "scratch".to_string(),
             section_type: SectionType::Text,
             content: "persisted".to_string(),

--- a/tests/rbmem_encryption.rs
+++ b/tests/rbmem_encryption.rs
@@ -41,7 +41,7 @@ fn encrypted_sections_are_skipped_unless_decrypt_is_enabled() {
     update(
         &file,
         UpdateOptions {
-        actor: "test".to_string(),
+            actor: "test".to_string(),
             section: "secrets.api".to_string(),
             section_type: SectionType::Text,
             content: "token=super-secret".to_string(),
@@ -117,7 +117,7 @@ fn encrypted_sections_are_queryable_only_with_decryption() {
     update(
         &file,
         UpdateOptions {
-        actor: "test".to_string(),
+            actor: "test".to_string(),
             section: "secrets.review".to_string(),
             section_type: SectionType::Text,
             content: "github review secret phrase".to_string(),

--- a/tests/rbmem_planner.rs
+++ b/tests/rbmem_planner.rs
@@ -1,0 +1,229 @@
+use chrono::{TimeZone, Utc};
+use rbmem::parser::parse_document;
+use rbmem::{plan_memory, PlanOptions, SatBackend, SatStatus, SectionType, TimestampPolicy};
+use std::fs;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+fn temp_test_dir(name: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("rbmem-plan-{name}-{suffix}"))
+}
+
+#[test]
+fn planner_stores_sat_plan_sections_and_graph_edges() {
+    let root = temp_test_dir("store");
+    fs::create_dir_all(&root).unwrap();
+    let file = root.join("memory.rbmem");
+    fs::write(
+        &file,
+        r#"meta:
+  version: 1.4.0
+  purpose: "planner test"
+  created_by: "test"
+
+[SECTION: goals]
+type: list
+content: |
+  - ship the release
+[END SECTION]
+
+[SECTION: tasks]
+type: list
+content: |
+  - Gather requirements
+  - Run tests
+  - Deploy release
+[END SECTION]
+
+[SECTION: rules]
+type: list
+content: |
+  - deploy release requires run tests
+  - gather requirements conflicts with deploy release
+[END SECTION]
+"#,
+    )
+    .unwrap();
+
+    let now = Utc.with_ymd_and_hms(2026, 5, 18, 20, 0, 0).unwrap();
+    let report = plan_memory(PlanOptions {
+        goal: Some("deploy release".to_string()),
+        from_memory: false,
+        file: Some(file.clone()),
+        search_dir: root.clone(),
+        context_pack: None,
+        solver: SatBackend::Internal,
+        proof: true,
+        proof_path: None,
+        verify_proof: false,
+        cube_and_conquer: false,
+        dry_run: false,
+        now,
+    })
+    .unwrap();
+
+    assert_eq!(report.status, SatStatus::Sat);
+    assert!(report
+        .steps
+        .iter()
+        .any(|step| step.action.contains("Run tests")));
+    assert!(report
+        .steps
+        .iter()
+        .any(|step| step.action.contains("Deploy release")));
+
+    let parsed = parse_document(
+        &fs::read_to_string(&file).unwrap(),
+        TimestampPolicy::Preserve,
+    )
+    .unwrap()
+    .document;
+    assert!(parsed.sections.iter().any(|section| {
+        section.path.ends_with(".steps")
+            && section.section_type == SectionType::List
+            && section.content.contains("Deploy release")
+    }));
+    assert!(parsed.sections.iter().any(|section| {
+        section.path.ends_with(".sat")
+            && section.section_type == SectionType::Json
+            && section
+                .content
+                .contains("\"schema\": \"rbmem.plan.sat.v1\"")
+    }));
+    assert!(parsed
+        .graph_view()
+        .edges
+        .iter()
+        .any(|edge| { edge.edge_type == "uses_context" && edge.to == "tasks" }));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn planner_can_derive_goal_from_memory_without_writing_on_dry_run() {
+    let root = temp_test_dir("from-memory");
+    fs::create_dir_all(&root).unwrap();
+    let file = root.join("memory.rbmem");
+    fs::write(
+        &file,
+        r#"meta:
+  version: 1.4.0
+
+[SECTION: goals]
+type: list
+content: |
+  - produce a code review
+[END SECTION]
+
+[SECTION: tasks]
+type: list
+content: |
+  - Inspect the diff
+  - Run focused tests
+  - Write the code review
+[END SECTION]
+"#,
+    )
+    .unwrap();
+    let before = fs::read_to_string(&file).unwrap();
+
+    let report = plan_memory(PlanOptions {
+        goal: None,
+        from_memory: true,
+        file: Some(file.clone()),
+        search_dir: root.clone(),
+        context_pack: None,
+        solver: SatBackend::Internal,
+        proof: false,
+        proof_path: None,
+        verify_proof: false,
+        cube_and_conquer: true,
+        dry_run: true,
+        now: Utc.with_ymd_and_hms(2026, 5, 18, 20, 1, 0).unwrap(),
+    })
+    .unwrap();
+
+    assert_eq!(report.goal, "produce a code review");
+    assert_eq!(report.status, SatStatus::Sat);
+    assert!(report.dry_run);
+    assert_eq!(fs::read_to_string(&file).unwrap(), before);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn planner_honors_context_pack_includes() {
+    let root = temp_test_dir("pack");
+    fs::create_dir_all(&root).unwrap();
+    let file = root.join("memory.rbmem");
+    fs::write(
+        root.join(".rbmempacks"),
+        r#"[pack: release]
+include:
+  - tasks.release
+"#,
+    )
+    .unwrap();
+    fs::write(
+        &file,
+        r#"meta:
+  version: 1.4.0
+
+[SECTION: goals]
+type: list
+content: |
+  - deploy release
+[END SECTION]
+
+[SECTION: tasks.release]
+type: list
+content: |
+  - Run release tests
+  - Deploy release
+[END SECTION]
+
+[SECTION: tasks.unrelated]
+type: list
+content: |
+  - Archive old notes
+[END SECTION]
+
+[SECTION: rules.release]
+type: list
+content: |
+  - deploy release requires run release tests
+[END SECTION]
+"#,
+    )
+    .unwrap();
+
+    let report = plan_memory(PlanOptions {
+        goal: Some("deploy release".to_string()),
+        from_memory: false,
+        file: Some(file),
+        search_dir: root.clone(),
+        context_pack: Some("release".to_string()),
+        solver: SatBackend::Internal,
+        proof: false,
+        proof_path: None,
+        verify_proof: false,
+        cube_and_conquer: false,
+        dry_run: true,
+        now: Utc.with_ymd_and_hms(2026, 5, 18, 20, 2, 0).unwrap(),
+    })
+    .unwrap();
+
+    assert!(report
+        .context_sections
+        .contains(&"tasks.release".to_string()));
+    assert!(!report
+        .steps
+        .iter()
+        .any(|step| step.action.contains("Archive old notes")));
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## Summary

Adds SAT-backed planning as a first-class RBMEM feature. The new `rbmem plan` command extracts goals, tasks, rules, constraints, preferences, and optional context packs from `.rbmem`, encodes them as CNF, solves with Kissat/CaDiCaL when available or a native DPLL fallback, and writes plan artifacts back into the RBMEM graph.

## What changed

- Added `src/planner/` with CNF generation, internal DPLL solving, external solver fallback, proof metadata, simple DRAT verification support, Cube-and-Conquer mode, context-pack filtering, and RBMEM plan persistence.
- Added CLI support for `rbmem plan`, including `--from-memory`, `--file`, `--pack`, `--solver`, `--proof`, `--verify-proof`, `--cube-and-conquer`, `--dry-run`, and `--format json`.
- Exported the planner API from the `rbmem` library.
- Added planner examples under `examples/sat-planning.rbmem` and `examples/.rbmempacks`.
- Updated README, Hermes guidance, and architecture docs.
- Added integration tests for planner persistence, goal derivation, context packs, graph relations, and solver behavior.
- Ran `cargo fmt` and cleaned the existing warning causes in `src/commands.rs`.

## Validation

- `cargo fmt --check`
- `cargo check -q`
- `cargo test -q`
- CLI dry-runs against `examples/sat-planning.rbmem` using internal solver, context pack mode, `--from-memory`, and Cube-and-Conquer mode.